### PR TITLE
feature: Allow passing in PHFetchOptions for albums and smart albums

### DIFF
--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -197,6 +197,11 @@ class ExampleViewController: UIViewController {
 		//config.fonts.navigationBarTitleFont = UIFont.systemFont(ofSize: 22.0, weight: .heavy)
 		//config.fonts.leftBarButtonFont = UIFont.systemFont(ofSize: 22.0, weight: .heavy)
 
+        // Customize order of albums
+        //let albumFetchOptions = PHFetchOptions()
+        //albumFetchOptions.sortDescriptors = [NSSortDescriptor(key: "title", ascending: true)]
+        //config.library.albumFetchOptions = albumFetchOptions
+
         let picker = YPImagePicker(configuration: config)
 
         picker.imagePickerDelegate = self

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -187,6 +187,10 @@ public struct YPConfigLibrary {
     
     public var options: PHFetchOptions?
 
+    public var albumFetchOptions: PHFetchOptions?
+
+    public var smartAlbumFetchOptions: PHFetchOptions?
+
     /// Set this to true if you want to force the library output to be a squared image. Defaults to false.
     public var onlySquare = false
     

--- a/Source/Pages/Gallery/Album/YPAlbumsManager.swift
+++ b/Source/Pages/Gallery/Album/YPAlbumsManager.swift
@@ -13,21 +13,22 @@ import UIKit
 class YPAlbumsManager {
     
     private var cachedAlbums: [YPAlbum]?
-    
+
     func fetchAlbums() -> [YPAlbum] {
         if let cachedAlbums = cachedAlbums {
             return cachedAlbums
         }
         
         var albums = [YPAlbum]()
-        let options = PHFetchOptions()
+        let albumFetchOptions = buildPHFetchOptions(YPConfig.library.albumFetchOptions)
+        let smartAlbumFetchOptions = buildPHFetchOptions(YPConfig.library.smartAlbumFetchOptions)
         
         let smartAlbumsResult = PHAssetCollection.fetchAssetCollections(with: .smartAlbum,
                                                                         subtype: .any,
-                                                                        options: options)
+                                                                        options: smartAlbumFetchOptions)
         let albumsResult = PHAssetCollection.fetchAssetCollections(with: .album,
                                                                    subtype: .any,
-                                                                   options: options)
+                                                                   options: albumFetchOptions)
         for result in [smartAlbumsResult, albumsResult] {
             result.enumerateObjects({ assetCollection, _, _ in
                 var album = YPAlbum()
@@ -71,6 +72,13 @@ class YPAlbumsManager {
         options.predicate = YPConfig.library.mediaType.predicate()
         let result = PHAsset.fetchAssets(in: collection, options: options)
         return result.count
+    }
+
+    func buildPHFetchOptions(_ optionOverride: PHFetchOptions?) -> PHFetchOptions {
+        if let userOpt = optionOverride {
+            return userOpt
+        }
+        return PHFetchOptions()
     }
     
 }


### PR DESCRIPTION
This will allow overriding the default `PHFetchOptions` used for fetching albums like this:

```
let albumFetchOptions = PHFetchOptions()
albumFetchOptions.sortDescriptors = [NSSortDescriptor(key: "title", ascending: true)]
config.library.albumFetchOptions = albumFetchOptions
```

### Screenshots of the example app

| Scenario | Before      | After |
|----- | ----------- | ----------- |
| Album view sorted by title | ![Simulator Screen Shot - iPhone 13 mini - 2023-02-16 at 10 13 50](https://user-images.githubusercontent.com/122308456/219443469-3a91a9ef-101e-4a98-9997-2e0f5f2de44a.png) | ![Simulator Screen Shot - iPhone 13 mini - 2023-02-16 at 10 14 16](https://user-images.githubusercontent.com/122308456/219443544-889bc2cc-6adc-4c7d-81ef-5bb2d6a073ff.png) |


This change is needed to resolve [this ticket](https://app.shortcut.com/rewardstyle/story/231965/change-order-of-photo-albums-when-selecting-asset)

