### PR TITLE
feature: Allow turning on "album sections", instagram style

### DIFF
--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -202,6 +202,11 @@ class ExampleViewController: UIViewController {
         //albumFetchOptions.sortDescriptors = [NSSortDescriptor(key: "title", ascending: true)]
         //config.library.albumFetchOptions = albumFetchOptions
 
+        // Arrange albums into sections
+        //config.library.useAlbumSections = true
+        //config.library.smartAlbumsSectionTitle = "Media types"
+        //config.library.userAlbumsSectionTitle = "My albums"
+
         let picker = YPImagePicker(configuration: config)
 
         picker.imagePickerDelegate = self

--- a/Source/Configuration/YPColors.swift
+++ b/Source/Configuration/YPColors.swift
@@ -59,6 +59,9 @@ public struct YPColors {
     /// The default color of all navigation bars except album's.
     public var defaultNavigationBarColor: UIColor = .offWhiteOrBlack
 
+    /// The color for album section header label (if album sections are on)
+    public var albumSectionHeaderTextColor: UIColor?
+
     // MARK: - Trimmer
     
     /// The color of the main border of the view

--- a/Source/Configuration/YPFonts.swift
+++ b/Source/Configuration/YPFonts.swift
@@ -40,4 +40,7 @@ public struct YPFonts {
 
     /// The font used in the UINavigationBar leftBarButtonItem
     public var leftBarButtonFont: UIFont?
+
+    /// The font used for album section header labels (if album sectioning is turned on)
+    public var albumSectionHeaderFont: UIFont?
 }

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -191,6 +191,12 @@ public struct YPConfigLibrary {
 
     public var smartAlbumFetchOptions: PHFetchOptions?
 
+    public var useAlbumSections = false
+
+    public var smartAlbumsSectionTitle: String?
+
+    public var userAlbumsSectionTitle: String?
+
     /// Set this to true if you want to force the library output to be a squared image. Defaults to false.
     public var onlySquare = false
     


### PR DESCRIPTION
Using the `useAlbumSections` flag will split the albums view into three sections: "Recents & Favorites", "user albums" and "smart albums", with overridable section titles.

| Scenario |  | |
|----- | ----------- | -- |
| `config.library.useAlbumSections = true`, `config.library.smartAlbumsSectionTitle = "Media types"`, `config.library.userAlbumsSectionTitle = "My albums"` | ![Simulator Screen Shot - iPhone 13 mini - 2023-02-17 at 09 49 29](https://user-images.githubusercontent.com/122308456/219702627-1e3d767e-610c-4e40-a4d8-5235210e9d6b.png) | ![Simulator Screen Shot - iPhone 13 mini - 2023-02-17 at 09 49 32](https://user-images.githubusercontent.com/122308456/219702660-2e97a0fa-fc39-4143-88bd-72b123bae6cd.png) | 
| `config.library.useAlbumSections = false` | ![Simulator Screen Shot - iPhone 13 mini - 2023-02-17 at 10 58 27](https://user-images.githubusercontent.com/122308456/219703086-69add30c-fbcf-48a7-a7ba-7b45e7a4bd88.png)  |  |


This change is required to allow mimicking Instagram's image picker functionality. See more information in [this ticket](https://app.shortcut.com/rewardstyle/story/231965/change-order-of-photo-albums-when-selecting-asset).



