### PR TITLE
feature: Video muting + add support for a combined trim & cover view

### DIFF
--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -44,6 +44,7 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
     public var playbackTimeCheckerTimer: Timer?
     public var imageGenerator: AVAssetImageGenerator?
     public var isFromSelectionVC = false
+    public var shouldMute = false
 
     public let trimmerContainerView: UIView = {
         let v = UIView()
@@ -302,7 +303,7 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
 
             let rotated = !videoTrack.preferredTransform.isIdentity
 
-            if untrimmed && !cropped && !rotated {
+            if untrimmed && !cropped && !rotated && !shouldMute {
                 // if video remains untrimmed and uncropped, use existing video url to eliminate video transcoding effort
                 // we will be selecting a cover image next, use generic uiimage for now
                 self.completeSave(thumbnail: UIImage(), videoUrl: self.inputVideo.url, asset: self.inputVideo.asset)
@@ -313,7 +314,7 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
             let timeRange = CMTimeRange(start: startTime, end: endTime)
 
             // cropping and trimming simultaneously to reduce total transcoding time
-            mediaManager.fetchVideoUrlAndCrop(for: inputVideo.asset!, cropRect: inputVideo.cropRect!, timeRange: timeRange) { [weak self] (url) in
+            mediaManager.fetchVideoUrlAndCrop(for: inputVideo.asset!, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute) { [weak self] (url) in
                 DispatchQueue.main.async {
                     if let url = url {
                         self?.completeSave(thumbnail:  UIImage(), videoUrl: url, asset: self?.inputVideo.asset)

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -150,7 +150,7 @@ public class LibraryMediaManager {
         }
     }
 
-    func fetchVideoUrlAndCrop(for videoAsset: PHAsset, cropRect: CGRect, timeRange:CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), callback: @escaping (_ videoURL: URL?) -> Void) {
+    func fetchVideoUrlAndCrop(for videoAsset: PHAsset, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = true, callback: @escaping (_ videoURL: URL?) -> Void) {
         let videosOptions = PHVideoRequestOptions()
         videosOptions.isNetworkAccessAllowed = true
         videosOptions.deliveryMode = .highQualityFormat
@@ -170,7 +170,7 @@ public class LibraryMediaManager {
                           return
 
                       }
-                if let audioTrack = asset.tracks(withMediaType: AVMediaType.audio).first,
+                if !shouldMute, let audioTrack = asset.tracks(withMediaType: AVMediaType.audio).first,
                    let audioCompositionTrack = assetComposition.addMutableTrack(withMediaType: AVMediaType.audio,
                                                                                 preferredTrackID: kCMPersistentTrackID_Invalid) {
                     do {


### PR DESCRIPTION
This PR includes two changes that are needed to implement [sc-238169](https://app.shortcut.com/rewardstyle/story/238963/trim-cover-page-consolidation-video-muting-stream-1). 

## feature: Allow video muting
    
Add a new `shouldMute` parameter to YPVideoFiltersVC, which will allow subclasses to toggle whether the output video will be muted or not.
    
The muting itself is super simple, we just skip adding the audio track to the output. The only other change is basically to force the save flow to go through `fetchVideoUrlAndCrop` even if there was no cropping/trimming done, but the video should be muted.

## feature: Allow users to show Trim and Cover in the same view

Includes:
- allow overriding the `save` method by making it open (this is needed to allow the subclasses of YPVideoFiltersVC to do some additional logic before `save` is called)
- add an open method for switching the vc type
- create thumbnails for both vcTypes

## Screenshot (from the Creator app)

With this changes, the user of this library implement the following screen:

![Simulator Screen Shot - iPhone 13 mini - 2023-03-03 at 13 28 12](https://user-images.githubusercontent.com/122308456/222799200-d00a3271-8c27-4507-8927-17666067660d.png)
