### PR TITLE
feature: Allow overriding the picker title (moving the gallery button)

### DIFF
--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -207,6 +207,10 @@ class ExampleViewController: UIViewController {
         //config.library.smartAlbumsSectionTitle = "Media types"
         //config.library.userAlbumsSectionTitle = "My albums"
 
+        // Override title text
+        //config.showsLibraryButtonInTitle = false
+        //config.pickerTitleOverride = "Test"
+
         let picker = YPImagePicker(configuration: config)
 
         picker.imagePickerDelegate = self

--- a/Source/Configuration/YPColors.swift
+++ b/Source/Configuration/YPColors.swift
@@ -62,6 +62,9 @@ public struct YPColors {
     /// The color for album section header label (if album sections are on)
     public var albumSectionHeaderTextColor: UIColor?
 
+    /// The color of the button that changes between library and albums _when_ showsLibraryButtonInTitle is false
+    public var libraryScreenAlbumsButtonColor: UIColor = .ypLabel
+
     // MARK: - Trimmer
     
     /// The color of the main border of the view
@@ -82,7 +85,9 @@ public struct YPColors {
     public var progressBarTrackColor: UIColor = .ypSystemBackground
     /// The color of completed track for the progress bar
     public var progressBarCompletedColor: UIColor?
-    
+
+    // MARK: - Albums (unused)
+
     /// The color of the Album's NavigationBar background
     public var albumBarTintColor: UIColor = .ypSystemBackground
     /// The color of the Album's left and right items color

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -106,6 +106,12 @@ public struct YPImagePickerConfiguration {
     /// Defines if the bottom bar should be hidden when showing the picker. Default is false.
     public var hidesBottomBar = false
 
+    /// Defines if the title bar should show the button that allows switching between the library and albums. If this is set to false, the button will be shown between the asset view and the library view instead
+    public var showsLibraryButtonInTitle = true
+
+    /// If showsLibraryButtonInTitle is false, this will be used as the title text instead
+    public var pickerTitleOverride: String? = nil
+
     /// Defines the preferredStatusBarAppearance
     public var preferredStatusBarStyle = UIStatusBarStyle.default
     

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -113,6 +113,10 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
 
             strongSelf.updateCropInfo()
         }
+
+        v.onAlbumsButtonTap = { [weak self] in
+            self?.delegate?.libraryViewDidTapAlbum()
+        }
     }
     
     public override func viewDidAppear(_ animated: Bool) {

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -49,11 +49,46 @@ internal final class YPLibraryView: UIView {
         return v
     }()
 
+    internal let showAlbumsButton: UIView = {
+        let buttonContainerView = UIView()
+
+        let label = UILabel()
+        label.text = YPConfig.wordings.libraryTitle
+        // Use YPConfig font
+        label.font = YPConfig.fonts.pickerTitleFont
+        label.textColor = YPConfig.colors.libraryScreenAlbumsButtonColor
+
+        let arrow = UIImageView()
+        arrow.image = YPConfig.icons.arrowDownIcon.withRenderingMode(.alwaysTemplate)
+        arrow.tintColor = YPConfig.colors.libraryScreenAlbumsButtonColor
+        arrow.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let button = UIButton()
+        button.addTarget(self, action: #selector(albumsButtonTapped), for: .touchUpInside)
+        button.setBackgroundColor(YPConfig.colors.assetViewBackgroundColor.withAlphaComponent(0.4), forState: .highlighted)
+
+        buttonContainerView.subviews(
+            label,
+            arrow,
+            button
+        )
+        button.fillContainer()
+        |-(24)-label.centerHorizontally()-arrow-(>=8)-|
+
+        label.firstBaselineAnchor.constraint(equalTo: buttonContainerView.bottomAnchor, constant: -24).isActive = true
+        arrow.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: -4).isActive = true
+
+        buttonContainerView.heightAnchor.constraint(equalToConstant: 60).isActive = true
+        return buttonContainerView
+    }()
+
+    var onAlbumsButtonTap: (() -> Void)?
+
     // MARK: - Private vars
 
     private let line: UIView = {
         let v = UIView()
-        v.backgroundColor = .ypSystemBackground
+        v.backgroundColor = YPConfig.colors.libraryScreenBackgroundColor
         return v
     }()
     /// When video is processing this bar appears
@@ -174,6 +209,7 @@ internal final class YPLibraryView: UIView {
             collectionContainerView.subviews(
                 collectionView
             ),
+            YPConfig.showsLibraryButtonInTitle ? UIView() : showAlbumsButton,
             line,
             assetViewContainer.subviews(
                 assetZoomableView
@@ -187,14 +223,23 @@ internal final class YPLibraryView: UIView {
         collectionContainerView.fillContainer()
         collectionView.fillHorizontally().bottom(0)
 
-        assetViewContainer.Bottom == line.Top
+        if !YPConfig.showsLibraryButtonInTitle {
+            assetViewContainer.Bottom == showAlbumsButton.Top
+            showAlbumsButton.Bottom == line.Top
+            showAlbumsButton.height(60)
+            assetZoomableView.Bottom == collectionView.Top - 60
+        } else {
+            assetViewContainer.Bottom == line.Top
+            assetZoomableView.Bottom == collectionView.Top
+        }
+
         line.height(1)
         line.fillHorizontally()
 
         assetViewContainer.top(0).fillHorizontally().heightEqualsWidth()
         self.assetViewContainerConstraintTop = assetViewContainer.topConstraint
         assetZoomableView.fillContainer().heightEqualsWidth()
-        assetZoomableView.Bottom == collectionView.Top
+
         assetViewContainer.sendSubviewToBack(assetZoomableView)
 
         progressView.height(5).fillHorizontally()
@@ -203,5 +248,10 @@ internal final class YPLibraryView: UIView {
         |maxNumberWarningView|.bottom(0)
         maxNumberWarningView.Top == safeAreaLayoutGuide.Bottom - 40
         maxNumberWarningLabel.centerHorizontally().top(11)
+    }
+
+    @objc
+    func albumsButtonTapped() {
+        onAlbumsButtonTap?()
     }
 }

--- a/Source/Pages/Gallery/YPLibraryViewDelegate.swift
+++ b/Source/Pages/Gallery/YPLibraryViewDelegate.swift
@@ -16,4 +16,5 @@ public protocol YPLibraryViewDelegate: AnyObject {
     func libraryViewDidToggleMultipleSelection(enabled: Bool)
     func libraryViewShouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool
     func libraryViewHaveNoItems()
+    func libraryViewDidTapAlbum()
 }

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -287,7 +287,13 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         }
         switch mode {
         case .library:
-            setTitleViewWithTitle(aTitle: libraryVC?.title ?? "")
+            if YPConfig.showsLibraryButtonInTitle {
+                setTitleViewWithTitle(aTitle: libraryVC?.title ?? "")
+            }
+            else if YPConfig.pickerTitleOverride != nil {
+                navigationItem.title = YPConfig.pickerTitleOverride
+            }
+
             navigationItem.rightBarButtonItem = UIBarButtonItem(title: YPConfig.wordings.next,
                                                                 style: .done,
                                                                 target: self,
@@ -387,5 +393,9 @@ extension YPPickerVC: YPLibraryViewDelegate {
     
     public func libraryViewShouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool {
         return pickerVCDelegate?.shouldAddToSelection(indexPath: indexPath, numSelections: numSelections) ?? true
+    }
+
+    public func libraryViewDidTapAlbum() {
+        navBarTapped()
     }
 }


### PR DESCRIPTION
Add a new configuration parameter called showsLibraryButtonInTitle, defaulting to true (which is the original implementation). If the variable is set to false, the Library button will be shown between the asset view and the library view instead. In addition to the new boolean, add another new variable (pickerTitleOverride) that will allow overriding the title of the picker view when the showsLibraryButtonInTitle is set to false.

### Screenshots:

With the title overridden, showing the Library button: 

```
config.showsLibraryButtonInTitle = false
config.pickerTitleOverride = "Test"
```

| Scenario | Screenshot      |
|----- | ----------- | ----------- |
| Title overridden ```
config.showsLibraryButtonInTitle = false
config.pickerTitleOverride = "Test"
``` | ![Simulator Screen Shot - iPhone 13 mini - 2023-03-09 at 11 27 08](https://user-images.githubusercontent.com/122308456/224088151-3aec7afd-655e-4ddd-af57-0fb2d4d2636b.png) |
| Default functionality | ![Simulator Screen Shot - iPhone 13 mini - 2023-03-09 at 11 28 37](https://user-images.githubusercontent.com/122308456/224088574-e66ebf13-d6bc-4ad9-9b0e-4a90b0be76ff.png) | 





