### PR TITLE
fix: When the picker title is overridden, set the album title correctly

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -89,7 +89,11 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
 
     func setAlbum(_ album: YPAlbum) {
-        title = album.title
+        if YPConfig.showsLibraryButtonInTitle {
+            title = album.title
+        } else {
+            v.setAlbumButtonTitle(aTitle: album.title)
+        }
         mediaManager.collection = album.collection
         currentlySelectedIndex = 0
         if !isMultipleSelectionEnabled {

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -12,6 +12,8 @@ import Photos
 
 internal final class YPLibraryView: UIView {
 
+    static let ALBUMS_LABEL_TAG = 100
+
     // MARK: - Public vars
 
     internal let assetZoomableViewMinimalVisibleHeight: CGFloat  = 50
@@ -57,6 +59,7 @@ internal final class YPLibraryView: UIView {
         // Use YPConfig font
         label.font = YPConfig.fonts.pickerTitleFont
         label.textColor = YPConfig.colors.libraryScreenAlbumsButtonColor
+        label.tag = ALBUMS_LABEL_TAG
 
         let arrow = UIImageView()
         arrow.image = YPConfig.icons.arrowDownIcon.withRenderingMode(.alwaysTemplate)
@@ -172,6 +175,13 @@ internal final class YPLibraryView: UIView {
         progressView.isHidden = progress > 0.99 || progress == 0
         progressView.progress = progress
         UIView.animate(withDuration: 0.1, animations: progressView.layoutIfNeeded)
+    }
+
+    func setAlbumButtonTitle(aTitle: String) {
+        guard !YPConfig.showsLibraryButtonInTitle else { return }
+        if let label = showAlbumsButton.viewWithTag(YPLibraryView.ALBUMS_LABEL_TAG) as? UILabel {
+            label.text = aTitle
+        }
     }
 
     // MARK: Crop Rect

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -211,7 +211,9 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         
         vc.didSelectAlbum = { [weak self] album in
             self?.libraryVC?.setAlbum(album)
-            self?.setTitleViewWithTitle(aTitle: album.title)
+            if YPConfig.showsLibraryButtonInTitle {
+                self?.setTitleViewWithTitle(aTitle: album.title)
+            }
             navVC.dismiss(animated: true, completion: nil)
         }
         present(navVC, animated: true, completion: nil)


### PR DESCRIPTION
When the showsLibraryButtonInTitle config value was set to false, we still incorrectly set the picker view title to the old "button" style.

| Scenario | Before      | After |
|----- | ----------- | ----------- |
| Album selected, showsLibraryButtonInTitle = false |  ![Simulator Screen Shot - iPhone 13 mini - 2023-04-06 at 12 40 16](https://user-images.githubusercontent.com/122308456/230442408-68738f47-35fd-44a0-b3aa-9b91310c272b.png) | ![Simulator Screen Shot - iPhone 13 mini - 2023-04-06 at 12 37 52](https://user-images.githubusercontent.com/122308456/230442087-3496cb84-1a53-4fca-8909-d1cefb653079.png) |
| Album selected, showsLibraryButtonInTitle = true (default functionality) | ![Simulator Screen Shot - iPhone 13 mini - 2023-04-06 at 12 40 56](https://user-images.githubusercontent.com/122308456/230442585-2be05817-2b2f-4565-835f-62374c3ed528.png) | ![Simulator Screen Shot - iPhone 13 mini - 2023-04-06 at 12 38 27](https://user-images.githubusercontent.com/122308456/230442202-6110e1ca-56b8-43ba-bd2d-3e2e470f05d2.png) |







