### PR TITLE
fix: Fix slomo videos potentially breaking when muting them

### DIFF
--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -154,6 +154,9 @@ public class LibraryMediaManager {
         let videosOptions = PHVideoRequestOptions()
         videosOptions.isNetworkAccessAllowed = true
         videosOptions.deliveryMode = .highQualityFormat
+
+        let videoIsSlomo = videoAsset.mediaSubtypes.contains(.videoHighFrameRate)
+
         imageManager?.requestAVAsset(forVideo: videoAsset, options: videosOptions) { asset, _, _ in
             do {
                 guard let asset = asset else { ypLog("⚠️ PHCachingImageManager >>> Don't have the asset"); return }
@@ -194,7 +197,7 @@ public class LibraryMediaManager {
 
                 // 5. Configuring export session
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
-                let presetName = videoIsCropped || videoIsTrimmed || videoIsRotated ? YPConfig.video.compression : AVAssetExportPresetPassthrough
+                let presetName = videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoIsSlomo) ? YPConfig.video.compression : AVAssetExportPresetPassthrough
 
                 var videoComposition:AVMutableVideoComposition?
 


### PR DESCRIPTION
We had already made a change earlier to _not_ use AVAssetExportPresetPassthrough for slomo videos here: https://github.com/rewardStyle/YPImagePicker/pull/9, but there was still a case where the user could end up with that preset if they didn't trim, crop or rotate the video but muted it. 

This change will force using `YPConfig.video.compression` in that case (which defaults to `AVAssetExportPresetHighestQuality`)