### PR TITLE
fix: Prevent a crash when allowZoomToCrop = false

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -515,9 +515,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                                     let video = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
                                                              videoURL: videoURL, asset: asset)
 
-                                    if YPConfig.library.allowZoomToCrop {
-                                        video.cropRect = self.getCropRect(for: asset)
-                                    }
+                                    video.cropRect = self.getCropRect(for: asset)
                                     videoCallback(video)
                                 } else {
                                     ypLog("YPLibraryVC -> selectedMedia -> Problems with fetching videoURL.")


### PR DESCRIPTION
The problem was that a few methods are expecting a cropRect to exist, so we shouldn't _not_ set it. We're already preventing the user from zooming/panning on the YPAssetZoomableView so this should be fine. 