### PR TITLE
fix: Always enforce video asset cropping to min asset ratios

### DIFF
--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -479,13 +479,19 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
 
     private func generateCoverImageAtTime(_ time: CMTime) {
         imageGenerator?.generateCGImagesAsynchronously(forTimes: [NSValue(time:time)],
-                                                       completionHandler: { (_, image, _, _, _) in
+                                                       completionHandler: { [weak self] (_, image, _, _, _) in
             guard let image = image else {
                 return
             }
 
             // it's safe to create UIImages off the main thread
-            let uiimage = UIImage(cgImage: image)
+
+            var uiimage: UIImage
+            if let cropRect = self?.inputVideo.cropRect, let croppedCGImage = image.cropping(to: cropRect) {
+                uiimage = UIImage(cgImage: croppedCGImage)
+            } else {
+                uiimage = UIImage(cgImage: image)
+            }
 
             DispatchQueue.main.async { [weak self] in
                 self?.imageGenerator?.cancelAllCGImageGeneration()

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -159,14 +159,17 @@ final class YPAssetZoomableView: UIScrollView {
         clipsToBounds = true
         photoImageView.frame = CGRect(origin: CGPoint.zero, size: CGSize.zero)
         videoView.frame = CGRect(origin: CGPoint.zero, size: CGSize.zero)
-        maximumZoomScale = 3.0
-        minimumZoomScale = 1
         showsHorizontalScrollIndicator = false
         showsVerticalScrollIndicator = false
+        maximumZoomScale = 3.0
+        minimumZoomScale = 1
+        delegate = self
         if YPConfig.library.allowZoomToCrop {
-            delegate = self
             alwaysBounceHorizontal = true
             alwaysBounceVertical = true
+        } else {
+            maximumZoomScale = 1.0
+            minimumZoomScale = 1.0
         }
     }
 
@@ -241,6 +244,10 @@ fileprivate extension YPAssetZoomableView {
         if isVideoMode {
             isScrollEnabled = true
             maximumZoomScale = 3.0
+            if !YPConfig.library.allowZoomToCrop {
+                maximumZoomScale = zoomScale
+                minimumZoomScale = zoomScale
+            }
         } else {
             isScrollEnabled = false // can't scroll for images
             maximumZoomScale = zoomScale


### PR DESCRIPTION
The problem was that if allowZoomToCrop was set to false, we didn't force the aspect ratio to the minimum allowed aspect ratio.

Also: Make the cover selector images respect the video aspect ratio