### PR TITLE
Image selection limit warning

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -228,7 +228,10 @@ public struct YPConfigLibrary {
 
     /// Anything superior than 1 will enable the multiple selection feature.
     public var maxNumberOfItems = 1
-    
+
+    /// Show warning when user has selected `maxNumberOfItems` and multiple selection is enabled.
+    public var showMaxNumberWarning = true
+
     /// Anything greater than 1 will desactivate live photo and video modes (library only) and
     /// force users to select at least the number of items defined.
     public var minNumberOfItems = 1

--- a/Source/Pages/Gallery/BottomPager/YPBottomPagerView.swift
+++ b/Source/Pages/Gallery/BottomPager/YPBottomPagerView.swift
@@ -29,12 +29,12 @@ final class YPBottomPagerView: UIView {
             0,
             |header| ~ 44
         )
-        
+        var offset = header.frame.height
         if #available(iOS 11.0, *) {
-            header.Bottom == safeAreaLayoutGuide.Bottom
-        } else {
-            header.bottom(0)
+            offset += safeAreaInsets.bottom
         }
+        
+        header.bottom(offset)
         header.heightConstraint?.constant = (YPConfig.hidesBottomBar || (YPConfig.screens.count == 1)) ? 0 : 44
         
         clipsToBounds = false

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -101,6 +101,7 @@ extension YPLibraryVC {
     
     /// Checks if there can be selected more items. If no - present warning.
     func checkLimit() {
+        guard YPConfig.library.showMaxNumberWarning else { return }
         v.maxNumberWarningView.isHidden = !isLimitExceeded || isMultipleSelectionEnabled == false
     }
 }

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -387,12 +387,6 @@ extension YPPickerVC: YPLibraryViewDelegate {
     }
     
     public func libraryViewDidToggleMultipleSelection(enabled: Bool) {
-        var offset = v.header.frame.height
-        if #available(iOS 11.0, *) {
-            offset += v.safeAreaInsets.bottom
-        }
-        
-        v.header.bottomConstraint?.constant = enabled ? offset : 0
         v.layoutIfNeeded()
         updateUI()
         didTapMultipleSelection?(enabled)


### PR DESCRIPTION
Add config to disable max selected items warning
Remove back bar from bottom of library view when selecting single item to be more consistent with multiple selection that doesn't have the bar