### PR TITLE
feat: Add Support For Mixed Photo + Video Library Selection [CC-495]

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -68,9 +68,6 @@ public struct YPImagePickerConfiguration {
     /// Adds a Video Trimmer step in the video taking process.  Defaults to true
     public var showsVideoTrimmer = true
 
-    /// Allows selection of both photo and video from the photo gallery.
-    public var allowPhotoAndVideoSelection : Bool = false
-    
     /// Enables you to opt out from saving new (or old but filtered) images to the
     /// user's photo library. Defaults to true.
     public var shouldSaveNewPicturesToAlbum = true
@@ -256,6 +253,9 @@ public struct YPConfigLibrary {
 
     /// Set this to true if you want to allow the library video picker to zoom / pan to crop videos
     public var allowZoomToCrop = true
+
+    /// Allow selection of both photo and video from the photo gallery.
+    public var allowPhotoAndVideoSelection : Bool = false
 }
 
 /// Encapsulates video specific settings.

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -67,6 +67,9 @@ public struct YPImagePickerConfiguration {
     
     /// Adds a Video Trimmer step in the video taking process.  Defaults to true
     public var showsVideoTrimmer = true
+
+    /// Allows selection of both photo and video from the photo gallery.
+    public var allowPhotoAndVideoSelection : Bool = false
     
     /// Enables you to opt out from saving new (or old but filtered) images to the
     /// user's photo library. Defaults to true.

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -183,12 +183,10 @@ public class LibraryMediaManager {
                     }
                 }
 
-                if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
-                    do {
-                        try videoCompositionTrack.insertTimeRange(trackTimeRange, of: videoTrack, at: CMTime.zero)
-                    } catch {
-                        ypLog("Unexpected error: \(error).")
-                    }
+                do {
+                    try videoCompositionTrack.insertTimeRange(trackTimeRange, of: videoTrack, at: CMTime.zero)
+                } catch {
+                    ypLog("Unexpected error: \(error).")
                 }
 
                 var transform = videoTrack.preferredTransform
@@ -200,13 +198,7 @@ public class LibraryMediaManager {
                 // 5. Configuring export session
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
 
-                var presetName: String = ""
-                if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
-                    presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
-                } else {
-                    presetName = AVAssetExportPresetHighestQuality
-                }
-
+                let presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
                 var videoComposition:AVMutableVideoComposition?
 
                 if videoIsCropped {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -230,12 +230,12 @@ public class LibraryMediaManager {
                 let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
                     .appendingUniquePathComponent(pathExtension: YPConfig.video.fileType.fileExtension)
                 let exportSession = assetComposition
-                    .export(to: fileURL,
-                            presetName: presetName) { [weak self] session in
 //                    .export(to: fileURL,
-//                            videoComposition: videoComposition,
-//                            removeOldFile: true,
 //                            presetName: presetName) { [weak self] session in
+                    .export(to: fileURL,
+                            videoComposition: videoComposition,
+                            removeOldFile: true,
+                            presetName: presetName) { [weak self] session in
                         DispatchQueue.main.async {
                             switch session.status {
                             case .completed:

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -183,11 +183,13 @@ public class LibraryMediaManager {
                     }
                 }
 
-//                do {
-//                    try videoCompositionTrack.insertTimeRange(trackTimeRange, of: videoTrack, at: CMTime.zero)
-//                } catch {
-//                    ypLog("Unexpected error: \(error).")
-//                }
+                if !YPImagePickerConfiguration.shared.allowPhotoAndVideoSelection {
+                    do {
+                        try videoCompositionTrack.insertTimeRange(trackTimeRange, of: videoTrack, at: CMTime.zero)
+                    } catch {
+                        ypLog("Unexpected error: \(error).")
+                    }
+                }
 
                 var transform = videoTrack.preferredTransform
                 let videoSize = videoTrack.naturalSize.applying(transform)
@@ -197,7 +199,13 @@ public class LibraryMediaManager {
 
                 // 5. Configuring export session
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
-//                let presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
+
+                var presetName: String = ""
+                if !YPImagePickerConfiguration.shared.allowPhotoAndVideoSelection {
+                    presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
+                } else {
+                    presetName = AVAssetExportPresetHighestQuality
+                }
 
                 var videoComposition:AVMutableVideoComposition?
 
@@ -226,12 +234,9 @@ public class LibraryMediaManager {
                 }
 
 
-                let presetName = AVAssetExportPresetHighestQuality
                 let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
                     .appendingUniquePathComponent(pathExtension: YPConfig.video.fileType.fileExtension)
                 let exportSession = assetComposition
-//                    .export(to: fileURL,
-//                            presetName: presetName) { [weak self] session in
                     .export(to: fileURL,
                             videoComposition: videoComposition,
                             removeOldFile: true,

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -183,11 +183,11 @@ public class LibraryMediaManager {
                     }
                 }
 
-                do {
-                    try videoCompositionTrack.insertTimeRange(trackTimeRange, of: videoTrack, at: CMTime.zero)
-                } catch {
-                    ypLog("Unexpected error: \(error).")
-                }
+//                do {
+//                    try videoCompositionTrack.insertTimeRange(trackTimeRange, of: videoTrack, at: CMTime.zero)
+//                } catch {
+//                    ypLog("Unexpected error: \(error).")
+//                }
 
                 var transform = videoTrack.preferredTransform
                 let videoSize = videoTrack.naturalSize.applying(transform)
@@ -197,7 +197,7 @@ public class LibraryMediaManager {
 
                 // 5. Configuring export session
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
-                let presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
+//                let presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
 
                 var videoComposition:AVMutableVideoComposition?
 
@@ -225,13 +225,17 @@ public class LibraryMediaManager {
                     videoCompositionTrack.preferredTransform = transform
                 }
 
+
+                let presetName = AVAssetExportPresetHighestQuality
                 let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
                     .appendingUniquePathComponent(pathExtension: YPConfig.video.fileType.fileExtension)
                 let exportSession = assetComposition
                     .export(to: fileURL,
-                            videoComposition: videoComposition,
-                            removeOldFile: true,
                             presetName: presetName) { [weak self] session in
+//                    .export(to: fileURL,
+//                            videoComposition: videoComposition,
+//                            removeOldFile: true,
+//                            presetName: presetName) { [weak self] session in
                         DispatchQueue.main.async {
                             switch session.status {
                             case .completed:

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -183,7 +183,7 @@ public class LibraryMediaManager {
                     }
                 }
 
-                if !YPImagePickerConfiguration.shared.allowPhotoAndVideoSelection {
+                if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
                     do {
                         try videoCompositionTrack.insertTimeRange(trackTimeRange, of: videoTrack, at: CMTime.zero)
                     } catch {
@@ -201,7 +201,7 @@ public class LibraryMediaManager {
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
 
                 var presetName: String = ""
-                if !YPImagePickerConfiguration.shared.allowPhotoAndVideoSelection {
+                if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
                     presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
                 } else {
                     presetName = AVAssetExportPresetHighestQuality

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -233,7 +233,6 @@ public class LibraryMediaManager {
                     videoCompositionTrack.preferredTransform = transform
                 }
 
-
                 let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
                     .appendingUniquePathComponent(pathExtension: YPConfig.video.fileType.fileExtension)
                 let exportSession = assetComposition

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -145,7 +145,7 @@ extension YPLibraryVC: UICollectionViewDelegate {
         cell.durationLabel.isHidden = !isVideo
         cell.durationLabel.text = isVideo ? YPHelper.formattedStrigFrom(asset.duration) : ""
 
-        if !YPImagePickerConfiguration.shared.allowPhotoAndVideoSelection {
+        if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
             cell.multipleSelectionIndicator.isHidden = !isMultipleSelectionEnabled || (isMultipleSelectionEnabled && isVideo)
             cell.isUserInteractionEnabled = !(isMultipleSelectionEnabled && isVideo)
         } else {

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -145,6 +145,8 @@ extension YPLibraryVC: UICollectionViewDelegate {
         cell.durationLabel.isHidden = !isVideo
         cell.durationLabel.text = isVideo ? YPHelper.formattedStrigFrom(asset.duration) : ""
 
+        cell.isSelected = !disableAutomaticCellSelection && currentlySelectedIndex == indexPath.row && selectedItems.contains(where: { $0.assetIdentifier == asset.localIdentifier })
+
         if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
             cell.multipleSelectionIndicator.isHidden = !isMultipleSelectionEnabled || (isMultipleSelectionEnabled && isVideo)
             cell.isUserInteractionEnabled = !(isMultipleSelectionEnabled && isVideo)
@@ -152,9 +154,6 @@ extension YPLibraryVC: UICollectionViewDelegate {
             cell.multipleSelectionIndicator.isHidden = !isMultipleSelectionEnabled
             cell.isUserInteractionEnabled = true
         }
-
-
-        cell.isSelected = !disableAutomaticCellSelection && currentlySelectedIndex == indexPath.row && selectedItems.contains(where: { $0.assetIdentifier == asset.localIdentifier })
 
         // Set correct selection number
         if let index = selectedItems.firstIndex(where: { $0.assetIdentifier == asset.localIdentifier }) {

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -144,7 +144,16 @@ extension YPLibraryVC: UICollectionViewDelegate {
         let isVideo = (asset.mediaType == .video)
         cell.durationLabel.isHidden = !isVideo
         cell.durationLabel.text = isVideo ? YPHelper.formattedStrigFrom(asset.duration) : ""
-        cell.multipleSelectionIndicator.isHidden = !isMultipleSelectionEnabled
+
+        if !YPImagePickerConfiguration.shared.allowPhotoAndVideoSelection {
+            cell.multipleSelectionIndicator.isHidden = !isMultipleSelectionEnabled || (isMultipleSelectionEnabled && isVideo)
+            cell.isUserInteractionEnabled = !(isMultipleSelectionEnabled && isVideo)
+        } else {
+            cell.multipleSelectionIndicator.isHidden = !isMultipleSelectionEnabled
+            cell.isUserInteractionEnabled = true
+        }
+
+
         cell.isSelected = !disableAutomaticCellSelection && currentlySelectedIndex == indexPath.row && selectedItems.contains(where: { $0.assetIdentifier == asset.localIdentifier })
         cell.isUserInteractionEnabled = true
         

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -144,9 +144,9 @@ extension YPLibraryVC: UICollectionViewDelegate {
         let isVideo = (asset.mediaType == .video)
         cell.durationLabel.isHidden = !isVideo
         cell.durationLabel.text = isVideo ? YPHelper.formattedStrigFrom(asset.duration) : ""
-        cell.multipleSelectionIndicator.isHidden = !isMultipleSelectionEnabled || (isMultipleSelectionEnabled && isVideo)
+        cell.multipleSelectionIndicator.isHidden = !isMultipleSelectionEnabled
         cell.isSelected = !disableAutomaticCellSelection && currentlySelectedIndex == indexPath.row && selectedItems.contains(where: { $0.assetIdentifier == asset.localIdentifier })
-        cell.isUserInteractionEnabled = !(isMultipleSelectionEnabled && isVideo)
+        cell.isUserInteractionEnabled = true
         
         // Set correct selection number
         if let index = selectedItems.firstIndex(where: { $0.assetIdentifier == asset.localIdentifier }) {

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -155,8 +155,7 @@ extension YPLibraryVC: UICollectionViewDelegate {
 
 
         cell.isSelected = !disableAutomaticCellSelection && currentlySelectedIndex == indexPath.row && selectedItems.contains(where: { $0.assetIdentifier == asset.localIdentifier })
-        cell.isUserInteractionEnabled = true
-        
+
         // Set correct selection number
         if let index = selectedItems.firstIndex(where: { $0.assetIdentifier == asset.localIdentifier }) {
             let currentSelection = selectedItems[index]

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -435,8 +435,11 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                                         y: yCrop,
                                         width: ts.width,
                                         height: ts.height)
-            mediaManager.fetchVideoUrl(for: asset, callback: callback)
-//            mediaManager.fetchVideoUrlAndCrop(for: asset, cropRect: resultCropRect, callback: callback)
+            if !YPImagePickerConfiguration.shared.allowPhotoAndVideoSelection {
+                mediaManager.fetchVideoUrlAndCrop(for: asset, cropRect: resultCropRect, callback: callback)
+            } else {
+                mediaManager.fetchVideoUrl(for: asset, callback: callback)
+            }
         }
     }
 

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -435,7 +435,8 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                                         y: yCrop,
                                         width: ts.width,
                                         height: ts.height)
-            mediaManager.fetchVideoUrlAndCrop(for: asset, cropRect: resultCropRect, callback: callback)
+            mediaManager.fetchVideoUrl(for: asset, callback: callback)
+//            mediaManager.fetchVideoUrlAndCrop(for: asset, cropRect: resultCropRect, callback: callback)
         }
     }
 

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -473,17 +473,17 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     }
 
                     // Fill result media items array
-                    var resultMediaItems: [YPMediaItem] = []
+                    var resultMediaItems: [YPMediaItem?] = Array(repeating: nil, count: selectedAssets.count)
                     let asyncGroup = DispatchGroup()
 
-                    for asset in selectedAssets {
+                    for (index, asset) in selectedAssets.enumerated() {
                         asyncGroup.enter()
 
                         switch asset.asset.mediaType {
                         case .image:
                             self.fetchImageAndCrop(for: asset.asset, withCropRect: asset.cropRect) { image, exifMeta in
                                 let photo = YPMediaPhoto(image: image.resizedImageIfNeeded(), exifMeta: exifMeta, asset: asset.asset)
-                                resultMediaItems.append(YPMediaItem.photo(p: photo))
+                                resultMediaItems[index] = YPMediaItem.photo(p: photo)
                                 asyncGroup.leave()
                             }
 
@@ -492,7 +492,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                                 if let videoURL = videoURL {
                                     let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
                                                                  videoURL: videoURL, asset: asset.asset)
-                                    resultMediaItems.append(YPMediaItem.video(v: videoItem))
+                                    resultMediaItems[index] = YPMediaItem.video(v: videoItem)
                                 } else {
                                     ypLog("YPLibraryVC -> selectedMedia -> Problems with fetching videoURL.")
                                 }
@@ -504,7 +504,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     }
 
                     asyncGroup.notify(queue: .main) {
-                        multipleItemsCallback(resultMediaItems)
+                        multipleItemsCallback(resultMediaItems.compactMap { $0 })
                         self.delegate?.libraryViewFinishedLoading()
                     }
                 } else {

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -435,7 +435,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                                         y: yCrop,
                                         width: ts.width,
                                         height: ts.height)
-            if !YPImagePickerConfiguration.shared.allowPhotoAndVideoSelection {
+            if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
                 mediaManager.fetchVideoUrlAndCrop(for: asset, cropRect: resultCropRect, callback: callback)
             } else {
                 mediaManager.fetchVideoUrl(for: asset, callback: callback)

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -206,16 +206,12 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                shouldSelectByDelegate,
                let asset = mediaManager.getAsset(at: currentlySelectedIndex) {
 
-               if  YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
-                    currentlySelectedIndex = 0
-                } else {
-                    // Change to first image if video is selected when switching to multiple selection mode
-                    if asset.mediaType == .video,
-                       case (let image?, let index?) = mediaManager.getFirstImageAsset()
-                    {
-                        currentlySelectedIndex = index
-                        changeAsset(image)
-                    }
+                if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection,
+                   asset.mediaType == .video,
+                   case (let image?, let index?) = mediaManager.getFirstImageAsset()
+                {
+                    currentlySelectedIndex = index
+                    changeAsset(image)
                 }
                 addToSelection(indexPath: IndexPath(row: currentlySelectedIndex, section: 0))
             }

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -206,12 +206,16 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                shouldSelectByDelegate,
                let asset = mediaManager.getAsset(at: currentlySelectedIndex) {
 
-                // Change to first image if video is selected when switching to multiple selection mode
-                if asset.mediaType == .video,
-                   case (let image?, let index?) = mediaManager.getFirstImageAsset()
-                {
-                    currentlySelectedIndex = index
-                    changeAsset(image)
+               if  YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
+                    currentlySelectedIndex = 0
+                } else {
+                    // Change to first image if video is selected when switching to multiple selection mode
+                    if asset.mediaType == .video,
+                       case (let image?, let index?) = mediaManager.getFirstImageAsset()
+                    {
+                        currentlySelectedIndex = index
+                        changeAsset(image)
+                    }
                 }
                 addToSelection(indexPath: IndexPath(row: currentlySelectedIndex, section: 0))
             }


### PR DESCRIPTION
This PR works off of https://github.com/rewardStyle/YPImagePicker/pull/26 as a starting point which adds new functionality to select both videos and images from the library. This PR adds a new property `allowPhotoAndVideoSelection` on `YPConfigLibrary` which can be toggled true/false from the client. When `allowPhotoAndVideoSelection` is set to true the client will be able to make mixed selection from the library. 