### PR TITLE
CC-550 Fix: When selecting media display auto cropping for additionally selected media assets

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -215,9 +215,7 @@ public struct YPConfigLibrary {
     public var minAspectRatio: CGFloat?
     
     public var maxAspectRatio: CGFloat?
-
-    public var allowedAspectRatios: [CGFloat]?
-
+    
     /// Choose what media types are available in the library. Defaults to `.photo`.
     /// If you define custom options PHFetchOptions var, than this will not work.
     public var mediaType = YPlibraryMediaType.photo

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -215,7 +215,9 @@ public struct YPConfigLibrary {
     public var minAspectRatio: CGFloat?
     
     public var maxAspectRatio: CGFloat?
-    
+
+    public var allowedAspectRatios: [CGFloat]?
+
     /// Choose what media types are available in the library. Defaults to `.photo`.
     /// If you define custom options PHFetchOptions var, than this will not work.
     public var mediaType = YPlibraryMediaType.photo

--- a/Source/Filters/Photo/YPCoverImageView.swift
+++ b/Source/Filters/Photo/YPCoverImageView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import Photos
-import Stevia
 
 public class YPCoverImageView: YPAdjustableView {
 
@@ -58,13 +57,5 @@ public class YPCoverImageView: YPAdjustableView {
 
         assetContainer.fillContainer()
         assetContainer.clipsToBounds = true
-    }
-
-    private func updateViewFrame(_ frame: CGRect) {
-        DispatchQueue.main.async {
-            self.coverImageView.layer.frame = frame
-            self.coverImageView.contentMode = .scaleAspectFill
-            self.coverImageView.clipsToBounds = true
-        }
     }
 }

--- a/Source/Filters/Photo/YPCoverImageView.swift
+++ b/Source/Filters/Photo/YPCoverImageView.swift
@@ -57,8 +57,10 @@ public class YPCoverImageView: YPAdjustableView {
     }
 
     private func updateViewFrame(_ frame: CGRect) {
-        coverImageView.layer.frame = frame
-        coverImageView.contentMode = .scaleAspectFill
-        coverImageView.clipsToBounds = true
+        DispatchQueue.main.async {
+            self.coverImageView.layer.frame = frame
+            self.coverImageView.contentMode = .scaleAspectFill
+            self.coverImageView.clipsToBounds = true
+        }
     }
 }

--- a/Source/Filters/Photo/YPCoverImageView.swift
+++ b/Source/Filters/Photo/YPCoverImageView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Photos
+import Stevia
 
 public class YPCoverImageView: YPAdjustableView {
 
@@ -45,11 +46,14 @@ public class YPCoverImageView: YPAdjustableView {
     }
 
     internal func setup() {
+        assetContainer.subviews(coverImageView)
+        coverImageView.fillContainer()
         subviews(
-            coverImageView
+            assetContainer
         )
 
-        coverImageView.fillContainer()
+        assetContainer.fillContainer()
+        assetContainer.clipsToBounds = true
     }
 
     private func updateViewFrame(_ frame: CGRect) {

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -109,6 +109,12 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
         coverImageView.cropRect = inputVideo.cropRect // pass the crop rect over to the video so it can present the video relative to the crop rect
         coverImageView.asset = inputVideo.asset // pass the asset over so we can use it to determine the original video dimensions
 
+        if let cropRect = inputVideo.cropRect {
+            let aspectRatio = cropRect.width / cropRect.height
+            videoView.targetAspectRatio = aspectRatio
+            coverImageView.targetAspectRatio = aspectRatio
+        }
+
         mediaManager.initialize()
         
         trimBottomItem.isHidden = true

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -507,17 +507,9 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
             }
 
             // it's safe to create UIImages off the main thread
-
-            var uiimage: UIImage
-            if let cropRect = self?.inputVideo.cropRect, let croppedCGImage = image.cropping(to: cropRect) {
-                uiimage = UIImage(cgImage: croppedCGImage)
-            } else {
-                uiimage = UIImage(cgImage: image)
-            }
-
             DispatchQueue.main.async { [weak self] in
                 self?.imageGenerator?.cancelAllCGImageGeneration()
-                self?.coverImageView.image = uiimage
+                self?.coverImageView.image = UIImage(cgImage: image)
                 self?.coverImageTime = time
             }
         })

--- a/Source/Filters/Video/YPVideoView.swift
+++ b/Source/Filters/Video/YPVideoView.swift
@@ -64,15 +64,18 @@ public class YPVideoView: YPAdjustableView {
         //playerView.alpha = 0
         playImageView.alpha = 0.8
         previewImageView.contentMode = .scaleAspectFit
-        
+
+        assetContainer.subviews(playerView)
+
         subviews(
             previewImageView,
-            playerView,
+            assetContainer,
             playImageView
         )
 
         previewImageView.fillContainer()
-        playerView.fillContainer()
+        assetContainer.fillContainer()
+        assetContainer.clipsToBounds = true
         playImageView.centerInContainer()
     }
 

--- a/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
+++ b/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
@@ -21,15 +21,29 @@ extension PHCachingImageManager {
     }
     
     func fetchImage(for asset: PHAsset,
-					cropRect: CGRect,
-					targetSize: CGSize,
 					callback: @escaping (UIImage, [String: Any]) -> Void) {
         let options = photoImageRequestOptions()
     
         // Fetch Highiest quality image possible.
         requestImageData(for: asset, options: options) { data, _, _, _ in
             if let data = data, let image = UIImage(data: data)?.resetOrientation() {
-            
+
+                let exifs = self.metadataForImageData(data: data)
+                callback(image, exifs)
+            }
+        }
+    }
+
+    func fetchImage(for asset: PHAsset,
+                    cropRect: CGRect,
+                    targetSize: CGSize,
+                    callback: @escaping (UIImage, [String: Any]) -> Void) {
+        let options = photoImageRequestOptions()
+
+        // Fetch Highiest quality image possible.
+        requestImageData(for: asset, options: options) { data, _, _, _ in
+            if let data = data, let image = UIImage(data: data)?.resetOrientation() {
+
                 // Crop the high quality image manually.
                 let xCrop: CGFloat = cropRect.origin.x * CGFloat(asset.pixelWidth)
                 let yCrop: CGFloat = cropRect.origin.y * CGFloat(asset.pixelHeight)
@@ -45,7 +59,7 @@ extension PHCachingImageManager {
             }
         }
     }
-    
+
     private func metadataForImageData(data: Data) -> [String: Any] {
         if let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
         let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil),

--- a/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
+++ b/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
@@ -25,7 +25,8 @@ extension PHCachingImageManager {
         let options = photoImageRequestOptions()
     
         // Fetch Highiest quality image possible.
-        requestImageData(for: asset, options: options) { data, _, _, _ in
+        requestImageData(for: asset, options: options) { [weak self] data, _, _, _ in
+            guard let self else { return }
             if let data = data, let image = UIImage(data: data)?.resetOrientation() {
 
                 let exifs = self.metadataForImageData(data: data)
@@ -41,7 +42,8 @@ extension PHCachingImageManager {
         let options = photoImageRequestOptions()
 
         // Fetch Highiest quality image possible.
-        requestImageData(for: asset, options: options) { data, _, _, _ in
+        requestImageData(for: asset, options: options) { [weak self] data, _, _, _ in
+            guard let self else { return }
             if let data = data, let image = UIImage(data: data)?.resetOrientation() {
 
                 // Crop the high quality image manually.

--- a/Source/Helpers/YPAdjustableView.swift
+++ b/Source/Helpers/YPAdjustableView.swift
@@ -9,6 +9,9 @@ import Photos
 import UIKit
 
 public class YPAdjustableView: UIView {
+    
+    var assetContainer = UIView(frame: .zero)
+
     public var updateViewFrameAction: ((CGRect) -> Void)?
 
     public func adjustViewFramesIfNeeded(cropRect: CGRect, asset: PHAsset, targetAspectRatio: CGFloat?) {
@@ -24,17 +27,17 @@ public class YPAdjustableView: UIView {
     // Method to adjust the view frame considering the asset's original size
     private func adjustViewFrame(cropRect: CGRect, assetSize: CGSize) {
         let assetRect = CGRect(origin: .zero, size: assetSize)
-        let fitFrame = calculateAspectFitFrame(assetSize: assetSize)
-        let targetFrame = calculateTargetFrame(cropRect: cropRect, assetRect: assetRect, fitFrame: fitFrame)
-        updateViewFrameAction?(targetFrame)
+        fitAspectAssetContainer(assetSize: assetSize)
+        let assetFrame = calculateAssetFrame(cropRect: cropRect, assetSize: assetSize)
+        updateViewFrameAction?(assetFrame)
     }
 
     // Method to adjust the view frame based on a target aspect ratio
     private func adjustViewFrameForAspectRatio(cropRect: CGRect, aspectRatio: CGFloat, assetSize: CGSize) {
         let adjustedAssetSize = adjustedSizeForAspectRatio(assetSize, aspectRatio: aspectRatio)
-        let fitFrame = calculateAspectFitFrame(assetSize: adjustedAssetSize)
-        let targetFrame = calculateTargetFrame(cropRect: cropRect, assetRect: CGRect(origin: .zero, size: adjustedAssetSize), fitFrame: fitFrame, adjustForAspectRatio: true)
-        updateViewFrameAction?(targetFrame)
+        fitAspectAssetContainer(assetSize: adjustedAssetSize)
+        let assetFrame = calculateAssetFrame(cropRect: cropRect, assetSize: assetSize)
+        updateViewFrameAction?(assetFrame)
     }
 
     // Calculate the adjusted size for the asset based on the target aspect ratio
@@ -48,33 +51,52 @@ public class YPAdjustableView: UIView {
     }
 
     // Calculate the frame for aspect fit scaling of the asset
-    private func calculateAspectFitFrame(assetSize: CGSize) -> CGRect {
+    private func fitAspectAssetContainer(assetSize: CGSize) {
         // Determine the scale factor to fit the asset in the current bounds
         let widthScale = bounds.size.width / assetSize.width
         let heightScale = bounds.size.height / assetSize.height
         let scale = min(widthScale, heightScale)
-        return CGRect(origin: .zero, size: CGSize(width: assetSize.width * scale, height: assetSize.height * scale))
+
+        var origin: CGPoint = .zero
+
+        if assetSize.width > assetSize.height {
+            let yPosition = (bounds.size.height / 2) - (assetSize.height * scale / 2)
+            origin = CGPoint(x: 0, y: yPosition)
+        } else {
+            let xPosition = (bounds.size.width / 2) - (assetSize.width * scale / 2)
+            origin = CGPoint(x:xPosition, y: 0)
+        }
+
+        let frame = CGRect(origin: origin, size: CGSize(width: assetSize.width * scale, height: assetSize.height * scale))
+        
+        assetContainer.frame = frame
     }
 
     // Calculate the target frame based on the crop rectangle and asset size
-    private func calculateTargetFrame(cropRect: CGRect, assetRect: CGRect, fitFrame: CGRect, adjustForAspectRatio: Bool = false) -> CGRect {
+    private func calculateAssetFrame(cropRect: CGRect, assetSize: CGSize) -> CGRect {
         // Determine the scaling factor needed for cropping
-        let scale = max(assetRect.size.width / cropRect.size.width, assetRect.size.height / cropRect.size.height)
-        var targetFrame = fitFrame.applying(CGAffineTransform(scaleX: scale, y: scale))
+        let scale = assetContainer.frame.width / assetSize.width
+        var assetFrame: CGRect = .zero
 
-        // Calculate offset scaling relative to the crop rectangle and asset rectangle centers
-        let xOffsetScale = (cropRect.midX - assetRect.midX) / assetRect.size.width
-        let yOffsetScale = (cropRect.midY - assetRect.midY) / assetRect.size.height
+        if assetContainer.frame.size.width > assetContainer.frame.size.height {
+            let zoomScale = assetSize.width / cropRect.size.width
 
-        // Adjust the target frame origin based on the calculated offsets
-        if adjustForAspectRatio {
-            targetFrame.origin.x = 0.5 * (bounds.size.width - targetFrame.size.width) - xOffsetScale
-            targetFrame.origin.y = 0.5 * (bounds.size.height - targetFrame.size.height) - yOffsetScale
+            let scaleFactor = assetContainer.frame.size.width / assetSize.width
+            let scaledHeight = scaleFactor * assetSize.height * zoomScale
+            assetFrame.size = CGSize(width: assetContainer.frame.size.width * zoomScale, height: scaledHeight)
+
+            assetFrame.origin.x = assetFrame.origin.x - (cropRect.origin.x * scaleFactor * zoomScale)
+            assetFrame.origin.y = assetFrame.origin.y - (cropRect.origin.y * scaleFactor * zoomScale)
         } else {
-            targetFrame.origin.x = 0.5 * (bounds.size.width - targetFrame.size.width) - xOffsetScale * targetFrame.size.width
-            targetFrame.origin.y = 0.5 * (bounds.size.height - targetFrame.size.height) - yOffsetScale * targetFrame.size.height
+            let zoomScale = assetSize.height / cropRect.size.height
+            let scaleFactor = assetContainer.frame.size.height / assetSize.height
+            let scaledWidth = scaleFactor * assetSize.width * zoomScale
+            assetFrame.size = CGSize(width: scaledWidth, height: assetContainer.frame.size.height * zoomScale)
+
+            assetFrame.origin.x = assetFrame.origin.x - (cropRect.origin.x * scaleFactor * zoomScale)
+            assetFrame.origin.y = assetFrame.origin.y - (cropRect.origin.y * scaleFactor * zoomScale)
         }
 
-        return targetFrame
+        return assetFrame
     }
 }

--- a/Source/Helpers/YPAdjustableView.swift
+++ b/Source/Helpers/YPAdjustableView.swift
@@ -29,7 +29,9 @@ public class YPAdjustableView: UIView {
         let assetRect = CGRect(origin: .zero, size: assetSize)
         fitAspectAssetContainer(assetSize: assetSize)
         let assetFrame = calculateAssetFrame(cropRect: cropRect, assetSize: assetSize)
-        updateViewFrameAction?(assetFrame)
+        DispatchQueue.main.async { [weak self] in
+            self?.updateViewFrameAction?(assetFrame)
+        }
     }
 
     // Method to adjust the view frame based on a target aspect ratio
@@ -37,7 +39,9 @@ public class YPAdjustableView: UIView {
         let adjustedAssetSize = adjustedSizeForAspectRatio(assetSize, aspectRatio: aspectRatio)
         fitAspectAssetContainer(assetSize: adjustedAssetSize)
         let assetFrame = calculateAssetFrame(cropRect: cropRect, assetSize: assetSize)
-        updateViewFrameAction?(assetFrame)
+        DispatchQueue.main.async { [weak self] in
+            self?.updateViewFrameAction?(assetFrame)
+        }
     }
 
     // Calculate the adjusted size for the asset based on the target aspect ratio

--- a/Source/Models/YPLibrarySelection.swift
+++ b/Source/Models/YPLibrarySelection.swift
@@ -14,7 +14,8 @@ public struct YPLibrarySelection {
     var scrollViewContentOffset: CGPoint?
     var scrollViewZoomScale: CGFloat?
     let assetIdentifier: String
-    
+    var isAspectRatioOutOfRange = false
+
     init(index: Int,
          cropRect: CGRect? = nil,
          scrollViewContentOffset: CGPoint? = nil,

--- a/Source/Models/YPMediaItem.swift
+++ b/Source/Models/YPMediaItem.swift
@@ -20,7 +20,8 @@ public class YPMediaPhoto {
     public let exifMeta: [String: Any]?
     public var asset: PHAsset?
     public var url: URL?
-    
+    public var cropRect: CGRect?
+
     public init(image: UIImage,
                 exifMeta: [String: Any]? = nil,
                 fromCamera: Bool = false,
@@ -61,6 +62,43 @@ public class YPMediaVideo {
 public enum YPMediaItem {
     case photo(p: YPMediaPhoto)
     case video(v: YPMediaVideo)
+
+    public var scale: CGFloat? {
+        switch self {
+        case .photo(let photo):
+            guard let pixelWidth = photo.asset?.pixelWidth,
+                  let cropWidth = photo.cropRect?.width
+            else { return nil }
+            return CGFloat(pixelWidth) / cropWidth
+        case .video(let video):
+            guard let pixelWidth = video.asset?.pixelWidth,
+                  let cropWidth = video.cropRect?.width
+            else { return nil }
+            return CGFloat(pixelWidth) / cropWidth
+        }
+    }
+
+    public var size: CGSize? {
+        switch self {
+        case .photo(let photo):
+            guard let pixelWidth = photo.asset?.pixelWidth,
+                  let pixelHeight = photo.asset?.pixelHeight
+            else { return nil }
+            return CGSize(width: pixelWidth, height: pixelHeight)
+        case .video(let video):
+            guard let pixelWidth = video.asset?.pixelWidth,
+                  let pixelHeight = video.asset?.pixelHeight
+            else { return nil }
+            return CGSize(width: pixelWidth, height: pixelHeight)
+        }
+    }
+
+    public var cropRect: CGRect? {
+        switch self {
+        case .photo(let photo): photo.cropRect
+        case .video(let video): video.cropRect
+        }
+    }
 }
 
 // MARK: - Compression

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -26,7 +26,6 @@ final class YPAssetViewContainer: UIView {
     private let spinner = UIActivityIndicatorView(style: .white)
     private var shouldCropToSquare = YPConfig.library.isSquareByDefault
 
-    private var isMultipleSelectionEnabled = false
     private var isSquareCropButtonEnabled = false
 
     public var itemOverlayType = YPConfig.library.itemOverlayType
@@ -104,7 +103,7 @@ final class YPAssetViewContainer: UIView {
     public func updateSquareCropButtonState() {
         let currentHiddenState = squareCropButton.isHidden
 
-        guard !isMultipleSelectionEnabled else {
+        guard !zoomableView.isMultipleSelectionEnabled else {
             // If multiple selection enabled, the squareCropButton is not visible
             squareCropButton.isHidden = true
             return
@@ -137,7 +136,8 @@ final class YPAssetViewContainer: UIView {
     
     /// Use this to update the multiple selection mode UI state for the YPAssetViewContainer
     public func setMultipleSelectionMode(on: Bool) {
-        isMultipleSelectionEnabled = on
+        zoomableView.isMultipleSelectionEnabled = on
+        zoomableView.multipleSelectionEnabled()
         updateSquareCropButtonState()
     }
 }
@@ -145,7 +145,7 @@ final class YPAssetViewContainer: UIView {
 // MARK: - ZoomableViewDelegate
 extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
     public func ypAssetZoomableViewDidLayoutSubviews(_ zoomableView: YPAssetZoomableView) {
-        let newFrame = zoomableView.assetImageView.convert(zoomableView.assetImageView.bounds, to: self)
+        let newFrame = zoomableView.convert(zoomableView.bounds, to: self)
         
         if let itemOverlay = itemOverlay {
             // update grid position
@@ -162,7 +162,7 @@ extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
     }
     
     public func ypAssetZoomableViewScrollViewDidZoom() {
-        guard let itemOverlay = itemOverlay else {
+        guard let itemOverlay = itemOverlay, zoomableView.isMultipleSelectionEnabled else {
             return
         }
         if isShown {
@@ -173,7 +173,7 @@ extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
     }
     
     public func ypAssetZoomableViewScrollViewDidEndZooming() {
-        guard let itemOverlay = itemOverlay else {
+        guard let itemOverlay = itemOverlay, zoomableView.isMultipleSelectionEnabled else {
             return
         }
         UIView.animate(withDuration: 0.3) {
@@ -195,7 +195,7 @@ extension YPAssetViewContainer: UIGestureRecognizerDelegate {
     
     @objc
     private func handleTouchDown(sender: UILongPressGestureRecognizer) {
-        guard let itemOverlay = itemOverlay else {
+        guard let itemOverlay = itemOverlay, zoomableView.isMultipleSelectionEnabled else {
             return
         }
         switch sender.state {

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -137,7 +137,7 @@ final class YPAssetViewContainer: UIView {
     /// Use this to update the multiple selection mode UI state for the YPAssetViewContainer
     public func setMultipleSelectionMode(on: Bool) {
         zoomableView.isMultipleSelectionEnabled = on
-        zoomableView.multipleSelectionEnabled()
+        zoomableView.restoreAssetToOriginalSize()
         updateSquareCropButtonState()
     }
 }

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -152,6 +152,7 @@ final class YPAssetZoomableView: UIScrollView {
             let imageSize = customSize ?? strongSelf.originalAssetSize
 
             strongSelf.photoImageView.image = image
+            strongSelf.layoutIfNeeded()
 
             strongSelf.setAssetFrame(with: imageSize)
 

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -29,7 +29,8 @@ final class YPAssetZoomableView: UIScrollView {
     public var minWidthForItem: CGFloat? = YPConfig.library.minWidthForItem
     public var maxAspectRatio: CGFloat? = YPConfig.library.maxAspectRatio
     public var minAspectRatio: CGFloat? = YPConfig.library.minAspectRatio
-    
+    public var isAspectRatioOutOfRange = false
+
     fileprivate var currentAsset: PHAsset?
     private var originalAssetSize: CGSize = .zero
 
@@ -247,6 +248,7 @@ fileprivate extension YPAssetZoomableView {
         var containerHeight: CGFloat = 0.0
 
         let aspectRatio: CGFloat = w / h
+        isAspectRatioOutOfRange = false
 
         if w > h { // Landscape
             containerWidth = screenWidth
@@ -255,6 +257,7 @@ fileprivate extension YPAssetZoomableView {
             if let maxAR = maxAspectRatio {
                 if aspectRatio > maxAR  && isVideoMode {
                     containerHeight = screenWidth / maxAR
+                    isAspectRatioOutOfRange = true
                 }
             }
         } else if h > w { // Portrait
@@ -264,6 +267,7 @@ fileprivate extension YPAssetZoomableView {
             if let minAR = minAspectRatio {
                 if aspectRatio < minAR  && isVideoMode {
                     containerWidth = screenWidth * minAR
+                    isAspectRatioOutOfRange = true
                 }
             }
 

--- a/Source/Pages/Gallery/YPGridView.swift
+++ b/Source/Pages/Gallery/YPGridView.swift
@@ -55,6 +55,9 @@ final class YPGridView: UIView {
         applyShadow(to: line2)
         applyShadow(to: line3)
         applyShadow(to: line4)
+
+        layer.borderWidth = stroke
+        layer.borderColor = color.cgColor
     }
     
     func applyShadow(to view: UIView) {

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -88,6 +88,7 @@ extension YPLibraryVC {
 
         let newSelection = YPLibrarySelection(index: indexPath.row, assetIdentifier: asset.localIdentifier)
         selectedItems.append(newSelection)
+        changeAsset(mediaManager.getAsset(at: indexPath.row))
         checkLimit()
     }
     

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -342,12 +342,16 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
 
     private func getFirstSelectedItemSize() -> CGSize? {
-        guard selectedItems.count > 0,
+        guard isMultipleSelectionEnabled,
               let firstSelectedItem = selectedItems.first,
-              let selectedAsset = mediaManager.getAsset(at: firstSelectedItem.index),
-              isMultipleSelectionEnabled else { return nil }
+              let cropRect = firstSelectedItem.cropRect,
+              let selectedAsset = mediaManager.getAsset(at: firstSelectedItem.index)
+        else { return nil }
 
-        return CGSize(width: selectedAsset.pixelWidth, height: selectedAsset.pixelHeight)
+        let width = firstSelectedItem.isAspectRatioOutOfRange ? CGFloat(selectedAsset.pixelWidth) * cropRect.width : CGFloat(selectedAsset.pixelWidth)
+        let height = firstSelectedItem.isAspectRatioOutOfRange ? CGFloat(selectedAsset.pixelHeight) * cropRect.height : CGFloat(selectedAsset.pixelHeight)
+
+        return CGSize(width: width, height: height)
     }
 
     // MARK: - Verification
@@ -387,6 +391,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
         selectedAsset.scrollViewContentOffset = v.assetZoomableView.contentOffset
         selectedAsset.scrollViewZoomScale = v.assetZoomableView.zoomScale
         selectedAsset.cropRect = v.currentCropRect()
+        selectedAsset.isAspectRatioOutOfRange = v.assetZoomableView.isAspectRatioOutOfRange
 
         // Replace
         selectedItems.remove(at: selectedAssetIndex)

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -347,9 +347,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
               let selectedAsset = mediaManager.getAsset(at: firstSelectedItem.index),
               isMultipleSelectionEnabled else { return nil }
 
-        let cropRectSize = getCropRect(for: selectedAsset, cropRect: firstSelectedItem.cropRect)
-
-        return cropRectSize.size
+        return CGSize(width: selectedAsset.pixelWidth, height: selectedAsset.pixelHeight)
     }
 
     // MARK: - Verification

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -342,11 +342,14 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
 
     private func getFirstSelectedItemSize() -> CGSize? {
-        guard let firstSelectedItem = selectedItems.first,
+        guard selectedItems.count > 0,
+              let firstSelectedItem = selectedItems.first,
               let selectedAsset = mediaManager.getAsset(at: firstSelectedItem.index),
               isMultipleSelectionEnabled else { return nil }
 
-        return CGSize(width: selectedAsset.pixelWidth, height: selectedAsset.pixelHeight)
+        let cropRectSize = getCropRect(for: selectedAsset, cropRect: firstSelectedItem.cropRect)
+
+        return cropRectSize.size
     }
 
     // MARK: - Verification

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -145,9 +145,6 @@ internal final class YPLibraryView: UIView {
 
     func hideOverlayView() {
         assetViewContainer.itemOverlay?.alpha = 0
-
-        // disable grid for images
-        assetViewContainer.itemOverlay?.isHidden = !assetZoomableView.isVideoMode
     }
 
     // MARK: Loader and progress
@@ -242,10 +239,10 @@ internal final class YPLibraryView: UIView {
             assetViewContainer.Bottom == showAlbumsButton.Top
             showAlbumsButton.Bottom == line.Top
             showAlbumsButton.height(60)
-            assetZoomableView.Bottom == collectionView.Top - 60
+            showAlbumsButton.Bottom == collectionView.Top
         } else {
             assetViewContainer.Bottom == line.Top
-            assetZoomableView.Bottom == collectionView.Top
+            line.Bottom == collectionView.Top
         }
 
         line.height(1)
@@ -253,7 +250,9 @@ internal final class YPLibraryView: UIView {
 
         assetViewContainer.top(0).fillHorizontally().heightEqualsWidth()
         self.assetViewContainerConstraintTop = assetViewContainer.topConstraint
-        assetZoomableView.fillContainer().heightEqualsWidth()
+        assetZoomableView.width(0)
+        assetZoomableView.height(0)
+        assetZoomableView.centerInContainer()
 
         assetViewContainer.sendSubviewToBack(assetZoomableView)
 


### PR DESCRIPTION
### Description: 
This PR enables the auto-cropping feature in the `YPImagePicker` library when selecting multiple media assets, automatically cropping the selected resources based on the first selected media asset size. Additionally, it resets the resources to their original state upon deactivating the selection of multiple media assets.

- Added a new `fetchImage` method for fetching original size images in `PHCachingImageManager`.
- Removed the validation that only allowed auto-cropping to videos.
- Changed the logic for resizing and centering media assets in `YPAssetZoomableView`.
- Added new properties in `YPMediaItem` for getting scale, size and crop measures.
- Change the logic for resizing videos in `YPAdjustableView`.
- Added a new container view for video assets in `YPVideoView` and `YPCoverImageView`

**Jira ticket:** [CC-550](https://rewardstyle.atlassian.net/browse/CC-550)

[CC-550]: https://rewardstyle.atlassian.net/browse/CC-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ