### PR TITLE
fix: [CC-917] Decrease Trimmer Timestamp Interval To Show Overflow

### DIFF
--- a/Source/Filters/Trim/YPTimeStampScrollView.swift
+++ b/Source/Filters/Trim/YPTimeStampScrollView.swift
@@ -80,16 +80,11 @@ class YPTimeStampScrollableView: UIScrollView {
         if totalSeconds < 30 {
             // Clips less then 30 seconds will have a scale of 1 dot = 1 second and every 5th dot will render a timestamp label.
             timeStamps = generateTimeStampViewModels(amount: Int(totalSeconds), timeStampInterval: 5, duration: 1)
-        } else if totalSeconds >= 30, totalSeconds <= 61 {
+        } else {
             let fiveSecondDivisor: Double = 5.0
             timeRangeAmount = round(totalSeconds / fiveSecondDivisor)
-            // Clips between 30 seconds and 61 seconds will have a scale of 1 dot = 5 seconds and every 3rd dot will render a timestamp label.
+            // Clips over 30 seconds will have a scale of 1 dot = 5 seconds and every 3rd dot will render a timestamp label.
             timeStamps = generateTimeStampViewModels(amount: Int(timeRangeAmount), timeStampInterval: 3, duration: 5)
-        } else {
-            let tenSecondDivisor: Double = 10
-            timeRangeAmount = round(totalSeconds / tenSecondDivisor)
-            // Clips greater then 61 seconds will have a scale of 1 dot = 10 seconds and every 3rd dot will render a timestmp label.
-            timeStamps = generateTimeStampViewModels(amount: Int(timeRangeAmount), timeStampInterval: 3, duration: 10)
         }
         return timeStamps
     }

--- a/Source/Filters/Trim/YPTimeStampScrollView.swift
+++ b/Source/Filters/Trim/YPTimeStampScrollView.swift
@@ -32,6 +32,7 @@ class YPTimeStampScrollableView: UIScrollView {
     var timeBarLargeCircleColor: UIColor?
     var timeBarSmallCircleColor: UIColor?
     var timeStampFont: UIFont?
+    var trimmerMaxDuration: Double = 0
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -80,11 +81,16 @@ class YPTimeStampScrollableView: UIScrollView {
         if totalSeconds < 30 {
             // Clips less then 30 seconds will have a scale of 1 dot = 1 second and every 5th dot will render a timestamp label.
             timeStamps = generateTimeStampViewModels(amount: Int(totalSeconds), timeStampInterval: 5, duration: 1)
-        } else {
+        } else if totalSeconds >= 30, totalSeconds <= 61 || min(trimmerMaxDuration, totalSeconds) == 60.0 {
             let fiveSecondDivisor: Double = 5.0
             timeRangeAmount = round(totalSeconds / fiveSecondDivisor)
-            // Clips over 30 seconds will have a scale of 1 dot = 5 seconds and every 3rd dot will render a timestamp label.
+            // Clips between 30 seconds and 61 seconds or if the trimmer max duration is 1 minute will have a scale of 1 dot = 5 seconds and every 3rd dot will render a timestamp label.
             timeStamps = generateTimeStampViewModels(amount: Int(timeRangeAmount), timeStampInterval: 3, duration: 5)
+        } else {
+            let tenSecondDivisor: Double = 10
+            timeRangeAmount = round(totalSeconds / tenSecondDivisor)
+            // Clips greater then 61 seconds will have a scale of 1 dot = 10 seconds and every 3rd dot will render a timestamp label.
+            timeStamps = generateTimeStampViewModels(amount: Int(timeRangeAmount), timeStampInterval: 3, duration: 10)
         }
         return timeStamps
     }

--- a/Source/Filters/Trim/YPTimeStampTrimmerView.swift
+++ b/Source/Filters/Trim/YPTimeStampTrimmerView.swift
@@ -105,6 +105,7 @@ public class YPTimeStampTrimmerView: UIView {
         timeStampScrollableView.timeStampFont = timeStampFont
         timeStampScrollableView.timeStampColor = timeStampColor
         timeStampScrollableView.isHidden = true
+        timeStampScrollableView.trimmerMaxDuration = trimmerView.maxDuration
         addSubview(timeStampScrollableView)
     }
 


### PR DESCRIPTION
Decreases the trimmer timestamp range interval for videos 30 seconds and over to render a timestamp dot every 5 seconds instead of every 10 seconds. This allows the UI to show that there is overflow indicating that a user can scroll the video clip in the video trimmer.