### PR TITLE
fix: Fix issues in asset centering, auto-cropping and processing

### DIFF
--- a/Source/Filters/Video/YPVideoView.swift
+++ b/Source/Filters/Video/YPVideoView.swift
@@ -112,7 +112,7 @@ extension YPVideoView {
 
         switch item.self {
         case let video as YPMediaVideo:
-            player = AVPlayer(url: video.url)
+            player = AVPlayer(url: video.originalUrl)
         case let url as URL:
             player = AVPlayer(url: url)
         case let playerItem as AVPlayerItem:

--- a/Source/Models/YPMediaItem.swift
+++ b/Source/Models/YPMediaItem.swift
@@ -40,6 +40,7 @@ public class YPMediaVideo {
     
     public var thumbnail: UIImage { return modifiedThumbnail ?? originalThumbnail }
     public let originalThumbnail: UIImage
+    public var selectedThumbnail: UIImage
     public var modifiedThumbnail: UIImage?
     public var url: URL { return modifiedUrl ?? originalUrl }
     public let originalUrl: URL
@@ -53,6 +54,7 @@ public class YPMediaVideo {
 
     public init(thumbnail: UIImage, videoURL: URL, fromCamera: Bool = false, asset: PHAsset? = nil) {
         self.originalThumbnail = thumbnail
+        self.selectedThumbnail = thumbnail
         self.originalUrl = videoURL
         self.fromCamera = fromCamera
         self.asset = asset

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -235,6 +235,7 @@ open class LibraryMediaManager {
                     videoComposition = AVMutableVideoComposition(propertiesOf: asset)
                     videoComposition?.instructions = [mainInstructions]
                     videoComposition?.renderSize = cropRect.size
+                    videoCompositionTrack.preferredTransform = videoTrack.preferredTransform
                 } else {
                     // transfer the transform so the video renders in the correct orientation
                     videoCompositionTrack.preferredTransform = transform

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -155,7 +155,8 @@ extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
         
         // Update play imageView position - bringing the playImageView from the videoView to assetViewContainer,
         // but the controll for appearing it still in videoView.
-        if zoomableView.videoView.playImageView.isDescendant(of: self) == false {
+        if zoomableView.videoView.playImageView.superview != self {
+            zoomableView.videoView.playImageView.removeFromSuperview()
             self.addSubview(zoomableView.videoView.playImageView)
             zoomableView.videoView.playImageView.centerInContainer()
         }

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -42,6 +42,8 @@ final class YPAssetZoomableView: UIScrollView {
 
     private let minimumTreshold: CGFloat = 0.001
 
+    public var isAnimating: Bool = false
+
     // Image view of the asset for convenience. Can be video preview image view or photo image view.
     public var assetImageView: UIImageView {
         return isVideoMode ? videoView.previewImageView : photoImageView
@@ -401,11 +403,19 @@ extension YPAssetZoomableView: UIScrollViewDelegate {
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         return isVideoMode ? videoView : photoImageView
     }
-    
+
+    func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
+        isAnimating = true
+    }
+
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
         zoomableViewDelegate?.ypAssetZoomableViewScrollViewDidZoom()
     }
-    
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        isAnimating = true
+    }
+
     func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
         guard let view = view, view == photoImageView || view == videoView else { return }
         
@@ -416,13 +426,16 @@ extension YPAssetZoomableView: UIScrollViewDelegate {
         
         zoomableViewDelegate?.ypAssetZoomableViewScrollViewDidEndZooming()
         cropAreaDidChange()
+        isAnimating = false
     }
     
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         cropAreaDidChange()
+        isAnimating = decelerate
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         cropAreaDidChange()
+        isAnimating = false
     }
 }

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -371,15 +371,26 @@ fileprivate extension YPAssetZoomableView {
         let scrollViewBoundsSize = bounds.size
         var assetFrame = assetView.frame
         let assetSize = assetView.frame.size
+        var yOffset = 0
+        var xOffset = 0
 
+        if assetSize.width > scrollViewBoundsSize.width {
+            xOffset = Int((assetSize.width - scrollViewBoundsSize.width) / 2.0)
+        }
+
+        if assetSize.height > scrollViewBoundsSize.height {
+            yOffset = Int((assetSize.height - scrollViewBoundsSize.height) / 2.0)
+        }
         assetFrame.origin.x = (assetSize.width < scrollViewBoundsSize.width) ?
         (scrollViewBoundsSize.width - assetSize.width) / 2.0 : 0
         assetFrame.origin.y = (assetSize.height < scrollViewBoundsSize.height) ?
         (scrollViewBoundsSize.height - assetSize.height) / 2.0 : 0.0
 
         assetView.frame = assetFrame
+        setContentOffset(CGPoint(x: xOffset, y: yOffset), animated: false)
 
         layoutIfNeeded()
+        cropAreaDidChange()
     }
 }
 
@@ -391,10 +402,6 @@ extension YPAssetZoomableView: UIScrollViewDelegate {
     
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
         zoomableViewDelegate?.ypAssetZoomableViewScrollViewDidZoom()
-        
-        DispatchQueue.main.async { [weak self] in
-            self?.centerAssetView()
-        }
     }
     
     func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -103,17 +103,17 @@ final class YPAssetZoomableView: UIScrollView {
             strongSelf.originalAssetSize = CGSize(width: video.pixelWidth, height: video.pixelHeight)
             let videoSize = customSize ?? strongSelf.originalAssetSize
 
-            strongSelf.setAssetFrame(with: videoSize)
+            strongSelf.setAssetFrame(with: videoSize, shouldCenter: storedCropPosition?.scrollViewContentOffset == nil)
             strongSelf.squaredZoomScale = strongSelf.calculateSquaredZoomScale()
-
-            completion()
 
             // Stored crop position in multiple selection
             if let scp173 = storedCropPosition {
                 strongSelf.applyStoredCropPosition(scp173)
-                // MARK: add update CropInfo after multiple
                 updateCropInfo()
             }
+
+            completion()
+
         }
         mediaManager.imageManager?.fetchPlayerItem(for: video) { [weak self] playerItem in
             guard let strongSelf = self else { return }
@@ -162,7 +162,7 @@ final class YPAssetZoomableView: UIScrollView {
             strongSelf.photoImageView.image = image
             strongSelf.layoutIfNeeded()
 
-            strongSelf.setAssetFrame(with: imageSize)
+            strongSelf.setAssetFrame(with: imageSize, shouldCenter: storedCropPosition?.scrollViewContentOffset == nil)
 
             // Stored crop position in multiple selection
             if let scp173 = storedCropPosition {
@@ -290,7 +290,7 @@ fileprivate extension YPAssetZoomableView {
         maximumZoomScale = (isMultipleSelectionEnabled || isVideoMode) && YPConfig.library.allowZoomToCrop ? 3 : 1
     }
 
-    func setAssetFrame(with size:CGSize) {
+    func setAssetFrame(with size:CGSize, shouldCenter: Bool = true) {
 
         let containerSize = getContainerSize(from: size)
         resizeZoomableView(size: containerSize)
@@ -298,9 +298,11 @@ fileprivate extension YPAssetZoomableView {
         setScrollView()
 
         // Centering image view
-        assetView.center = self.center
-        DispatchQueue.main.async { [weak self] in
-            self?.centerAssetView()
+        if shouldCenter {
+            assetView.center = self.center
+            DispatchQueue.main.async { [weak self] in
+                self?.centerAssetView()
+            }
         }
     }
 

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -22,6 +22,10 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     internal var isInitialized = false
     var disableAutomaticCellSelection = false
 
+    public var isAnimating: Bool {
+        v.assetZoomableView.isAnimating
+    }
+
     // MARK: - Init
 
     public override func loadView() {


### PR DESCRIPTION
This PR contains four separate fixes:

- Fix asset centering when they're being pre-cropped -- now the cropping should default to center properly
- Stop "zooming" the play button on top of videos in some situations
- Apply rotation transforms correctly when processing "cropped" videos
- Fix stored crop position not being applied correctly when re-selecting media in multi-selection mode