### PR TITLE
Make Video Processing Configurable

### DIFF
--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -162,9 +162,14 @@ class ExampleViewController: UIViewController {
 
         config.library.maxNumberOfItems = 10
         config.gallery.hidesRemoveButton = false
-//        config.library.allowedAspectRatios = [0.5625, 0.8, 1.0, 1.777778]
-        let allowedAspectRatios: [CGFloat] = [9/16, 2/3, 4/5, 1, 3/2]
-        config.library.allowedVideoAspectRatios = allowedAspectRatios
+        
+        let allowedVideoAspectRatios: [CGFloat] = [9/16, 2/3, 4/5, 1, 3/2]
+        config.library.allowedVideoAspectRatios = allowedVideoAspectRatios
+
+        let allowedMultipleSelectionAspectRatios: [CGFloat] = [4/5]
+        config.library.allowedMultiSelectionAspectRatios = allowedMultipleSelectionAspectRatios
+        let overrides: [CGFloat] = [1]
+        config.library.allowedMultiSelectionAspectRatioOverrides = overrides
         config.library.allowPhotoAndVideoSelection = true
 
         /* Disable scroll to change between mode */

--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -126,8 +126,8 @@ class ExampleViewController: UIViewController {
         /* Can forbid the items with very big height with this property */
         //config.library.minWidthForItem = UIScreen.main.bounds.width * 0.8
         
-        config.library.maxAspectRatio = 3 / 2
-        config.library.minAspectRatio = 2 / 3
+        config.library.maxAspectRatio = 16 / 9
+        config.library.minAspectRatio = 9 / 16
 
         /* Defines the time limit for recording videos.
            Default is 30 seconds. */
@@ -160,8 +160,12 @@ class ExampleViewController: UIViewController {
 
         config.maxCameraZoomFactor = 2.0
 
-        config.library.maxNumberOfItems = 5
+        config.library.maxNumberOfItems = 10
         config.gallery.hidesRemoveButton = false
+//        config.library.allowedAspectRatios = [0.5625, 0.8, 1.0, 1.777778]
+        let allowedAspectRatios: [CGFloat] = [9/16, 2/3, 4/5, 1, 3/2]
+        config.library.allowedVideoAspectRatios = allowedAspectRatios
+        config.library.allowPhotoAndVideoSelection = true
 
         /* Disable scroll to change between mode */
         // config.isScrollToChangeModesEnabled = false

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -215,7 +215,9 @@ public struct YPConfigLibrary {
     public var minAspectRatio: CGFloat?
     
     public var maxAspectRatio: CGFloat?
-    
+
+    public var allowedVideoAspectRatios: [CGFloat]?
+
     /// Choose what media types are available in the library. Defaults to `.photo`.
     /// If you define custom options PHFetchOptions var, than this will not work.
     public var mediaType = YPlibraryMediaType.photo

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -216,7 +216,21 @@ public struct YPConfigLibrary {
     
     public var maxAspectRatio: CGFloat?
 
+    /// List of aspect ratios allowed for videos (when selecting a single video)
+    /// The gallery will auto-crop the media to the closest aspect ratio from this list (without letterboxing)
     public var allowedVideoAspectRatios: [CGFloat]?
+
+    /// List of aspect ratios allowed for all media when multi-selecting
+    /// The gallery will auto-crop the media to the closest aspect ratio from this list (without letterboxing)
+    public var allowedMultiSelectionAspectRatios: [CGFloat]?
+
+    /// List of "override" aspect ratios allowed for all media in single video selection mode
+    /// These aspect ratios will not be used as the list of "allowed" aspect ratios but they are still "allowed"
+    public var allowedVideoAspectRatioOverrides: [CGFloat]?
+
+    /// List of "override" aspect ratios allowed for all media in multi-selection mode
+    /// These aspect ratios will not be used as the list of "allowed" aspect ratios but they are still "allowed"
+    public var allowedMultiSelectionAspectRatioOverrides: [CGFloat]?
 
     /// Choose what media types are available in the library. Defaults to `.photo`.
     /// If you define custom options PHFetchOptions var, than this will not work.

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -338,6 +338,11 @@ public struct YPConfigVideo {
     /// Defines whether the coverThumbSelector automatically reloads a trimmed version of the video asset \
     /// whenever the trim selection changes
     public var coverSelectionTrimmed: Bool = false
+
+    /// The maximum resolution allowed for outputted videos, calculated by multiplying the video's height and width.
+    /// The video's pixel size will be automatically restricted to fit within this amount (keeping the aspect ratio).
+    /// NOTE: Additionally, if this value is set, the resulting resolution values will be rounded down to the nearest even numbers.
+    public var maxVideoResolution: Double?
 }
 
 /// Encapsulates gallery specific settings.

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -290,7 +290,11 @@ public struct YPConfigVideo {
      - "AVAssetExportPresetPassthrough" // without any compression
      */
     public var compression: String = AVAssetExportPresetHighestQuality
-    
+
+    /// When `true` the video will always be processed using whatever whatever export preset is defined for `YPConfigVideo.compression. 
+    /// The default value is `false`.`
+    public var shouldAlwaysProcessVideo: Bool = false
+
     /// Choose the result video extension if you trim or compress a video. Defaults to mov.
     public var fileType: AVFileType = .mov
     

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -167,8 +167,6 @@ open class LibraryMediaManager {
         videosOptions.isNetworkAccessAllowed = true
         videosOptions.deliveryMode = .highQualityFormat
 
-        let videoNeedsProcessing = videoAsset.mediaSubtypes.contains(.videoHighFrameRate)
-
         imageManager?.requestAVAsset(forVideo: videoAsset, options: videosOptions) { asset, _, _ in
             do {
                 guard let asset = asset else { ypLog("⚠️ PHCachingImageManager >>> Don't have the asset"); return }
@@ -204,13 +202,10 @@ open class LibraryMediaManager {
                 var transform = videoTrack.preferredTransform
                 let videoSize = videoTrack.naturalSize.applying(transform)
 
-                let videoIsTrimmed = CMTimeCompare(videoTrack.timeRange.duration, timeRange.duration) != 0
-                let videoIsRotated = !transform.isIdentity // transcode the video if source is rotated.
-
                 // 5. Configuring export session
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
 
-                let presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
+                let  presetName = compressionTypeOverride ?? YPConfig.video.compression
                 var videoComposition:AVMutableVideoComposition?
 
                 if videoIsCropped {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -167,6 +167,8 @@ open class LibraryMediaManager {
         videosOptions.isNetworkAccessAllowed = true
         videosOptions.deliveryMode = .highQualityFormat
 
+        let videoNeedsProcessing = videoAsset.mediaSubtypes.contains(.videoHighFrameRate)
+
         imageManager?.requestAVAsset(forVideo: videoAsset, options: videosOptions) { asset, _, _ in
             do {
                 guard let asset = asset else { ypLog("⚠️ PHCachingImageManager >>> Don't have the asset"); return }
@@ -202,10 +204,13 @@ open class LibraryMediaManager {
                 var transform = videoTrack.preferredTransform
                 let videoSize = videoTrack.naturalSize.applying(transform)
 
+                let videoIsTrimmed = CMTimeCompare(videoTrack.timeRange.duration, timeRange.duration) != 0
+                let videoIsRotated = !transform.isIdentity // transcode the video if source is rotated.
+
                 // 5. Configuring export session
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
 
-                let  presetName = compressionTypeOverride ?? YPConfig.video.compression
+                let presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
                 var videoComposition:AVMutableVideoComposition?
 
                 if videoIsCropped {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -210,7 +210,15 @@ open class LibraryMediaManager {
                 // 5. Configuring export session
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
 
-                let presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
+                var presetName = ""
+
+                if YPConfig.video.shouldAlwaysProcessVideo {
+                    presetName = compressionTypeOverride ?? YPConfig.video.compression
+                } else {
+                    presetName = compressionTypeOverride ?? (videoIsCropped || videoIsTrimmed || videoIsRotated || (shouldMute && videoNeedsProcessing) ? YPConfig.video.compression : AVAssetExportPresetPassthrough)
+                }
+
+
                 var videoComposition:AVMutableVideoComposition?
 
                 if videoIsCropped {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -210,7 +210,7 @@ open class LibraryMediaManager {
                 // 5. Configuring export session
                 let videoIsCropped = cropRect.size.width < abs(videoSize.width) || cropRect.size.height < abs(videoSize.height)
 
-                var presetName = ""
+                let presetName: String
 
                 if YPConfig.video.shouldAlwaysProcessVideo {
                     presetName = compressionTypeOverride ?? YPConfig.video.compression

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -30,6 +30,10 @@ final class YPAssetZoomableView: UIScrollView {
     public var maxAspectRatio: CGFloat? = YPConfig.library.maxAspectRatio
     public var minAspectRatio: CGFloat? = YPConfig.library.minAspectRatio
     public var allowedVideoAspectRatios: [CGFloat]? = YPConfig.library.allowedVideoAspectRatios
+    public var allowedMultiSelectionAspectRatios: [CGFloat]? = YPConfig.library.allowedMultiSelectionAspectRatios
+
+    public var allowedVideoAspectRatioOverrides: [CGFloat]? = YPConfig.library.allowedVideoAspectRatioOverrides
+    public var allowedMultiSelectionAspectRatioOverrides: [CGFloat]? = YPConfig.library.allowedMultiSelectionAspectRatioOverrides
 
     public var isAspectRatioOutOfRange = false
 
@@ -308,7 +312,21 @@ fileprivate extension YPAssetZoomableView {
         if let minAR = minAspectRatio, aspectRatio < minAR {
             aspectRatioToReturn = minAR
         }
-        if let allowedAspectRatios = allowedVideoAspectRatios, !allowedAspectRatios.isEmpty, isVideoMode, !isMultipleSelectionEnabled {
+        if isVideoMode, !isMultipleSelectionEnabled, let aspectRatioOverrides = allowedVideoAspectRatioOverrides, aspectRatioOverrides.contains(where: { aspectRatio <= $0 + minimumTreshold && aspectRatio >= $0 - minimumTreshold }) {
+            return aspectRatio
+        }
+
+        if isMultipleSelectionEnabled, let aspectRatioOverrides = allowedMultiSelectionAspectRatioOverrides, aspectRatioOverrides.contains(where: { aspectRatio <= $0 + minimumTreshold && aspectRatio >= $0 - minimumTreshold }) {
+            return aspectRatio
+        }
+
+        var allowedAspectRatioList: [CGFloat]? = nil
+        if isVideoMode, !isMultipleSelectionEnabled, let allowedVideoAspectRatios = allowedVideoAspectRatios, !allowedVideoAspectRatios.isEmpty {
+            allowedAspectRatioList = allowedVideoAspectRatios
+        } else if isMultipleSelectionEnabled, let allowedMultiSelectionAspectRatios = allowedMultiSelectionAspectRatios,  !allowedMultiSelectionAspectRatios.isEmpty {
+            allowedAspectRatioList = allowedMultiSelectionAspectRatios
+        }
+        if let allowedAspectRatioList = allowedAspectRatioList {
             var closestAllowedAspectRatio: CGFloat?
             if aspectRatio < 1.0 { // portrait
                 // in this case, we need to find the next "larger" aspect ratio


### PR DESCRIPTION
This PR makes video processing configurable through a new `YPConfig` option. If this new config option is set by the client then processing will always occur and will prioritize using any provided `compressionTypeOverride`. If this config option is not set then normal processing rules apply.