### PR TITLE
Fix Slow Mo Processing

### DIFF
--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -292,11 +292,10 @@ open class LibraryMediaManager {
                                     // Try one more time to process with the export settings on the YPConfig.
                                     let compressionOverride = YPConfig.video.compression
                                     ypLog("LibraryMediaManager -> Export of the video failed. Reason: \(String(describing: session.error))\n--- Retrying with compression type \(compressionOverride)")
+                                    self.stopExportTimer(for: session)
                                     if retryCount > 1 {
-                                        self.stopExportTimer(for: session)
                                         callback(nil)
                                     } else {
-                                        self.stopExportTimer(for: session)
                                         self.fetchVideoUrlAndCrop(for: videoAsset, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionOverride, processingFailedRetryCount: retryCount , callback: callback)
                                     }
                                 } else {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -289,11 +289,18 @@ open class LibraryMediaManager {
                                 if let self = self {
                                     var retryCount = processingFailedRetryCount
                                     retryCount += 1
-                                    // Try one more time to process with the export settings on the YPConfig. If this fails again, use pass through as the final fallback.
-                                    let compressionOverride = retryCount == 1 ? YPConfig.video.compression : AVAssetExportPresetPassthrough
+                                    // Try one more time to process with the export settings on the YPConfig.
+                                    let compressionOverride = YPConfig.video.compression
                                     ypLog("LibraryMediaManager -> Export of the video failed. Reason: \(String(describing: session.error))\n--- Retrying with compression type \(compressionOverride)")
-                                    self.stopExportTimer(for: session)
-                                    self.fetchVideoUrlAndCrop(for: videoAsset, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionOverride, processingFailedRetryCount: retryCount , callback: callback)
+                                    if retryCount > 1 {
+                                        self.stopExportTimer(for: session)
+                                        callback(nil)
+                                    } else {
+                                        self.stopExportTimer(for: session)
+                                        self.fetchVideoUrlAndCrop(for: videoAsset, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionOverride, processingFailedRetryCount: retryCount , callback: callback)
+                                    }
+                                } else {
+                                    callback(nil)
                                 }
                             default:
                                 ypLog("LibraryMediaManager -> Export session completed with \(session.status) status. Not handling.")

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -192,8 +192,8 @@ internal final class YPLibraryView: UIView {
         let cropView = assetZoomableView
         let normalizedX = min(1, cropView.contentOffset.x &/ cropView.contentSize.width)
         let normalizedY = min(1, cropView.contentOffset.y &/ cropView.contentSize.height)
-        let normalizedWidth = min(1, cropView.frame.width / cropView.contentSize.width)
-        let normalizedHeight = min(1, cropView.frame.height / cropView.contentSize.height)
+        let normalizedWidth = min(1, cropView.frame.width / cropView.contentSize.width.rounded())
+        let normalizedHeight = min(1, cropView.frame.height / cropView.contentSize.height.rounded())
         return CGRect(x: normalizedX, y: normalizedY, width: normalizedWidth, height: normalizedHeight)
     }
 


### PR DESCRIPTION
Processing Slow Mo videos was previously failing. When these failures would occur the videos were processed with the passthrough preset. After some research it was found that the `AVMutableVideoComposition` was what was failing Slow Mo videos. This seemed to only trigger with Slow Mo videos that had audio disabled. Setting both `frameDuration` and `sourceTrackIDForFrameTiming` on the video composition allowed the videos to be processed without failure. This PR slightly changes the processing failed logic. Now processed videos will retry once more with Slow Mo video composition settings if processing fails the first time. However if the processing fails once more, then pass through is used as the final preset if all retry attempts fail as there might still be some edge cases that haven't been encountered yet.