### PR TITLE
feature: Add a way to add a custom "info view" to the library screen

### DIFF
--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -217,7 +217,7 @@ class ExampleViewController: UIViewController {
         //config.library.userAlbumsSectionTitle = "My albums"
 
         // Override title text
-        //config.showsLibraryButtonInTitle = false
+        config.showsLibraryButtonInTitle = false
         //config.pickerTitleOverride = "Test"
 
         let picker = YPImagePicker(configuration: config)

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -273,6 +273,8 @@ public struct YPConfigLibrary {
     /// Allow selection of both photo and video from the photo gallery.
     public var allowPhotoAndVideoSelection : Bool = false
 
+    /// A view you set here will be shown underneath the asset preview view in the library screen.
+    /// The view will be automatically laid out to fill the screen horizontally, but it should determine its own height. 
     public var assetPreviewFooterView: UIView?
 }
 

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -272,6 +272,8 @@ public struct YPConfigLibrary {
 
     /// Allow selection of both photo and video from the photo gallery.
     public var allowPhotoAndVideoSelection : Bool = false
+
+    public var assetPreviewFooterView: UIView?
 }
 
 /// Encapsulates video specific settings.

--- a/Source/Filters/Photo/YPCoverImageView.swift
+++ b/Source/Filters/Photo/YPCoverImageView.swift
@@ -14,6 +14,8 @@ public class YPCoverImageView: YPAdjustableView {
 
     var cropRect: CGRect?
     var asset: PHAsset?
+    var videoUrl: URL?
+
     public var image: UIImage? {
         get {
             coverImageView.image
@@ -44,8 +46,15 @@ public class YPCoverImageView: YPAdjustableView {
             self?.coverImageView.clipsToBounds = true
         }
         // Ensure necessary properties are available
-        guard let cropRect = cropRect, let asset = asset else { return }
-        adjustViewFramesIfNeeded(cropRect: cropRect, asset: asset, targetAspectRatio: targetAspectRatio)
+        guard let cropRect = cropRect else { return }
+        if let asset = asset {
+            adjustViewFramesIfNeeded(cropRect: cropRect, asset: asset, targetAspectRatio: targetAspectRatio)
+        } else if let videoUrl = videoUrl {
+            let videoAsset = AVAsset(url: videoUrl)
+            guard let track = videoAsset.tracks(withMediaType: AVMediaType.video).first else { return }
+            let size = track.naturalSize.applying(track.preferredTransform)
+            adjustViewFramesIfNeeded(cropRect: cropRect, assetSize: size, targetAspectRatio: targetAspectRatio)
+        }
     }
 
     internal func setup() {

--- a/Source/Filters/Photo/YPCoverImageView.swift
+++ b/Source/Filters/Photo/YPCoverImageView.swift
@@ -48,12 +48,12 @@ public class YPCoverImageView: YPAdjustableView {
         // Ensure necessary properties are available
         guard let cropRect = cropRect else { return }
         if let asset = asset {
-            adjustViewFramesIfNeeded(cropRect: cropRect, asset: asset, targetAspectRatio: targetAspectRatio)
+            adjustViewFrameIfNeeded(cropRect: cropRect, asset: asset, targetAspectRatio: targetAspectRatio)
         } else if let videoUrl = videoUrl {
             let videoAsset = AVAsset(url: videoUrl)
             guard let track = videoAsset.tracks(withMediaType: AVMediaType.video).first else { return }
             let size = track.naturalSize.applying(track.preferredTransform)
-            adjustViewFramesIfNeeded(cropRect: cropRect, assetSize: size, targetAspectRatio: targetAspectRatio)
+            adjustViewFrameIfNeeded(cropRect: cropRect, assetSize: size, targetAspectRatio: targetAspectRatio)
         }
     }
 

--- a/Source/Filters/Video/YPVideoView.swift
+++ b/Source/Filters/Video/YPVideoView.swift
@@ -47,6 +47,7 @@ public class YPVideoView: YPAdjustableView {
 
         updateViewFrameAction = { [weak self] frame in
             self?.playerView.layer.frame = frame
+            self?.playerView.playerLayer.speed = 999 // disable the "zoom in" animation
             self?.playerView.playerLayer.videoGravity = .resizeAspectFill
         }
 

--- a/Source/Filters/Video/YPVideoView.swift
+++ b/Source/Filters/Video/YPVideoView.swift
@@ -48,19 +48,19 @@ public class YPVideoView: YPAdjustableView {
 
         updateViewFrameAction = { [weak self] frame in
             self?.playerView.layer.frame = frame
-            self?.playerView.playerLayer.speed = 999 // disable the "zoom in" animation
+            self?.playerView.playerLayer.speed = 999 // disable the "zoom in" animation by making the animation speed "fast enough"
             self?.playerView.playerLayer.videoGravity = .resizeAspectFill
         }
 
         // Ensure necessary properties are available
         guard let cropRect = cropRect else { return }
         if let asset = asset {
-            adjustViewFramesIfNeeded(cropRect: cropRect, asset: asset, targetAspectRatio: targetAspectRatio)
+            adjustViewFrameIfNeeded(cropRect: cropRect, asset: asset, targetAspectRatio: targetAspectRatio)
         } else if let videoUrl = videoUrl {
             let videoAsset = AVAsset(url: videoUrl)
             guard let track = videoAsset.tracks(withMediaType: AVMediaType.video).first else { return }
             let size = track.naturalSize.applying(track.preferredTransform)
-            adjustViewFramesIfNeeded(cropRect: cropRect, assetSize: size, targetAspectRatio: targetAspectRatio)
+            adjustViewFrameIfNeeded(cropRect: cropRect, assetSize: size, targetAspectRatio: targetAspectRatio)
         }
     }
 
@@ -127,6 +127,7 @@ extension YPVideoView {
             videoUrl = url
             player = AVPlayer(url: url)
         case let playerItem as AVPlayerItem:
+            videoUrl = (playerItem.asset as? AVURLAsset)?.url
             player = AVPlayer(playerItem: playerItem)
         default:
             return

--- a/Source/Helpers/YPAdjustableView.swift
+++ b/Source/Helpers/YPAdjustableView.swift
@@ -14,7 +14,7 @@ public class YPAdjustableView: UIView {
 
     public var updateViewFrameAction: ((CGRect) -> Void)?
 
-    public func adjustViewFramesIfNeeded(cropRect: CGRect, asset: PHAsset, targetAspectRatio: CGFloat?) {
+    public func adjustViewFrameIfNeeded(cropRect: CGRect, asset: PHAsset, targetAspectRatio: CGFloat?) {
         let assetSize = CGSize(width: CGFloat(asset.pixelWidth), height: CGFloat(asset.pixelHeight))
 
         if let aspectRatio = targetAspectRatio, aspectRatio != assetSize.width / assetSize.height {
@@ -24,7 +24,7 @@ public class YPAdjustableView: UIView {
         }
     }
 
-    public func adjustViewFramesIfNeeded(cropRect: CGRect, assetSize: CGSize, targetAspectRatio: CGFloat?) {
+    public func adjustViewFrameIfNeeded(cropRect: CGRect, assetSize: CGSize, targetAspectRatio: CGFloat?) {
         if let aspectRatio = targetAspectRatio, aspectRatio != assetSize.width / assetSize.height {
             adjustViewFrameForAspectRatio(cropRect: cropRect, aspectRatio: aspectRatio, assetSize: assetSize)
         } else {

--- a/Source/Helpers/YPAdjustableView.swift
+++ b/Source/Helpers/YPAdjustableView.swift
@@ -24,6 +24,14 @@ public class YPAdjustableView: UIView {
         }
     }
 
+    public func adjustViewFramesIfNeeded(cropRect: CGRect, assetSize: CGSize, targetAspectRatio: CGFloat?) {
+        if let aspectRatio = targetAspectRatio, aspectRatio != assetSize.width / assetSize.height {
+            adjustViewFrameForAspectRatio(cropRect: cropRect, aspectRatio: aspectRatio, assetSize: assetSize)
+        } else {
+            adjustViewFrame(cropRect: cropRect, assetSize: assetSize)
+        }
+    }
+
     // Method to adjust the view frame considering the asset's original size
     private func adjustViewFrame(cropRect: CGRect, assetSize: CGSize) {
         let assetRect = CGRect(origin: .zero, size: assetSize)

--- a/Source/Pages/Gallery/YPLibraryVC+PanGesture.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+PanGesture.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
 
-    var v: YPLibraryViewPanning!
+    var pannedView: YPLibraryViewPanning!
     var targetView: UIView!
     private let assetViewContainerOriginalConstraintTop: CGFloat = 0
     private var dragDirection = YPDragDirection.up
@@ -24,11 +24,11 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
     // The height constraint of the view with main selected image
     var topHeight: CGFloat {
         get {
-            return v.imageContainerConstraintTop?.constant ?? 0
+            return pannedView.imageContainerConstraintTop?.constant ?? 0
         }
         set {
-            if newValue >= v.imageScrollViewMinimalVisibleHeight - v.imageContainerFrame.size.height {
-                v.imageContainerConstraintTop?.constant = newValue
+            if newValue >= pannedView.imageScrollViewMinimalVisibleHeight - pannedView.imageContainerFrame.size.height {
+                pannedView.imageContainerConstraintTop?.constant = newValue
             }
         }
     }
@@ -39,15 +39,15 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
         set {
             if newValue != isImageShown {
                 self._isImageShown = newValue
-                v.assetViewContainerIsShown = newValue
+                pannedView.assetViewContainerIsShown = newValue
                 // Update imageCropContainer
-                v.imageScrollViewScrollEnabled = isImageShown
+                pannedView.imageScrollViewScrollEnabled = isImageShown
             }
         }
     }
 
     public func registerForPanGesture(on view: YPLibraryViewPanning) {
-        v = view
+        pannedView = view
         targetView = view.targetView
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(panned(_:)))
         panGesture.delegate = self
@@ -62,7 +62,7 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
     }
 
     public func animateUp() {
-        topHeight = v.imageScrollViewMinimalVisibleHeight - v.imageContainerFrame.size.height
+        topHeight = pannedView.imageScrollViewMinimalVisibleHeight - pannedView.imageContainerFrame.size.height
         animateView()
         dragDirection = .down
     }
@@ -72,8 +72,8 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
                        delay: 0.0,
                        options: [.curveEaseInOut, .beginFromCurrentState],
                        animations: {
-                           self.v.updateImageContainerLayout()
-                           self.v.targetView.layoutIfNeeded()
+                           self.pannedView.updateImageContainerLayout()
+                           self.pannedView.targetView.layoutIfNeeded()
                        },
                        completion: nil)
     }
@@ -87,7 +87,7 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
         let p = gestureRecognizer.location(ofTouch: 0, in: targetView)
         // Desactivate pan on image when it is shown.
         if isImageShown {
-            if p.y < v.imageContainerFrame.height {
+            if p.y < pannedView.imageContainerFrame.height {
                 return false
             }
         }
@@ -97,7 +97,7 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
     @objc
     func panned(_ sender: UIPanGestureRecognizer) {
 
-        let containerHeight = v.imageContainerFrame.size.height + (v.collectionViewFrame.minY - v.imageContainerFrame.maxY)
+        let containerHeight = pannedView.imageContainerFrame.size.height + (pannedView.collectionViewFrame.minY - pannedView.imageContainerFrame.maxY)
         let currentPos = sender.location(in: targetView)
         let overYLimitToStartMovingUp = currentPos.y * 1.4 < cropBottomY
         switch sender.state {
@@ -106,13 +106,13 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
             let loc     = sender.location(in: view)
             let subview = view?.hitTest(loc, with: nil)
 
-            if subview == v.imageContainerView
+            if subview == pannedView.imageContainerView
                 && topHeight == assetViewContainerOriginalConstraintTop {
                 return
             }
 
             dragStartPos = sender.location(in: view)
-            cropBottomY = v.collectionViewFrame.minY
+            cropBottomY = pannedView.collectionViewFrame.minY
 
             // Move
             if dragDirection == .stop {
@@ -125,28 +125,28 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
             if dragDirection == .down && dragStartPos.y > cropBottomY {
                 dragDirection = .stop
             }
-            if (dragDirection == .up || dragDirection == .down) && currentPos.y < v.collectionViewFrame.minY {
-                dragDiff = currentPos.y - v.collectionViewFrame.minY
+            if (dragDirection == .up || dragDirection == .down) && currentPos.y < pannedView.collectionViewFrame.minY {
+                dragDiff = currentPos.y - pannedView.collectionViewFrame.minY
             }
 
         case .changed:
             switch dragDirection {
             case .up:
-                let diff = v.collectionViewFrame.minY - currentPos.y
+                let diff = pannedView.collectionViewFrame.minY - currentPos.y
                 if diff > 0 {
                     topHeight =
                         min(assetViewContainerOriginalConstraintTop,
-                            max(v.imageScrollViewMinimalVisibleHeight - containerHeight,
+                            max(pannedView.imageScrollViewMinimalVisibleHeight - containerHeight,
                                 (currentPos.y - dragDiff) - containerHeight))
                 }
             case .down:
                 topHeight = min(assetViewContainerOriginalConstraintTop, currentPos.y - dragDiff - containerHeight)
             case .scroll:
-                let newTopHeightValue = v.imageScrollViewMinimalVisibleHeight - v.imageContainerFrame.size.height
-                + (currentPos.y - v.collectionViewContentOffset.y) - imaginaryCollectionViewOffsetStartPosY
+                let newTopHeightValue = pannedView.imageScrollViewMinimalVisibleHeight - pannedView.imageContainerFrame.size.height
+                + (currentPos.y - pannedView.collectionViewContentOffset.y) - imaginaryCollectionViewOffsetStartPosY
                 topHeight = newTopHeightValue
             case .stop:
-                if topHeight != assetViewContainerOriginalConstraintTop && v.collectionViewContentOffset.y < 0 {
+                if topHeight != assetViewContainerOriginalConstraintTop && pannedView.collectionViewContentOffset.y < 0 {
                     dragDirection = .scroll
                     imaginaryCollectionViewOffsetStartPosY = currentPos.y
                 }

--- a/Source/Pages/Gallery/YPLibraryVC+PanGesture.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+PanGesture.swift
@@ -148,8 +148,8 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
             if sender.state == UIGestureRecognizer.State.ended && dragDirection == .stop {
                 return
             }
-            
-            if overYLimitToStartMovingUp && isImageShown == false {
+            let velocity = sender.velocity(in: v)
+            if (overYLimitToStartMovingUp && isImageShown == false) || (isImageShown == false && velocity.y < 0) {
                 // The largest movement
                 topHeight =
                     v.assetZoomableViewMinimalVisibleHeight - containerHeight

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -240,7 +240,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
     
     @objc
-    func tappedImage() {
+    public func tappedImage() {
         if !panGestureHelper.isImageShown {
             panGestureHelper.resetToOriginalState()
             // no dragup? needed? dragDirection = .up

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -76,7 +76,7 @@ internal final class YPLibraryView: UIView {
             button
         )
         button.fillContainer()
-        |-(24)-label.centerHorizontally()-arrow-(>=8)-|
+        |-(16)-label.centerHorizontally()-arrow-(>=8)-|
 
         label.firstBaselineAnchor.constraint(equalTo: buttonContainerView.bottomAnchor, constant: -24).isActive = true
         arrow.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: -4).isActive = true
@@ -236,7 +236,14 @@ internal final class YPLibraryView: UIView {
         collectionView.fillHorizontally().bottom(0)
 
         if !YPConfig.showsLibraryButtonInTitle {
-            assetViewContainer.Bottom == showAlbumsButton.Top
+            if let footerView = YPConfig.library.assetPreviewFooterView {
+                subviews(footerView)
+                footerView.fillHorizontally()
+                assetViewContainer.Bottom == footerView.Top
+                footerView.Bottom == showAlbumsButton.Top
+            } else {
+                assetViewContainer.Bottom == showAlbumsButton.Top
+            }
             showAlbumsButton.Bottom == line.Top
             showAlbumsButton.height(60)
             showAlbumsButton.Bottom == collectionView.Top
@@ -264,7 +271,7 @@ internal final class YPLibraryView: UIView {
         maxNumberWarningLabel.centerHorizontally().top(11)
 
         subviews(multipleSelectionButton)
-        multipleSelectionButton.size(30).trailing(20)
+        multipleSelectionButton.size(30).trailing(16)
         alignHorizontally(showAlbumsButton, multipleSelectionButton)
     }
 

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -195,7 +195,11 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             videoVC?.stopCamera()
         }
     }
-    
+
+    public func pausePlayer() {
+        libraryVC?.pausePlayer()
+    }
+
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         shouldHideStatusBar = false
@@ -335,7 +339,7 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     
     // When pressing "Next"
     @objc
-    func done() {
+    open func done() {
         guard let libraryVC = libraryVC else { ypLog("YPLibraryVC deallocated"); return }
         if libraryVC.isAnimating {
             self.navigationItem.rightBarButtonItem = YPLoaders.defaultLoader


### PR DESCRIPTION
This PR adds one new feature: ability to add a "footer" view underneath the asset preview on the library screen. 

Screenshot showing a simple "footer" view using the new configuration variable:

<img src="https://github.com/rewardStyle/YPImagePicker/assets/122308456/76adb25e-2899-49bb-8c11-7b027e653591" width=400 />

Additionally, the PR contains a few fixes and improvements: 
- Make some methods public to make subclassing easier
- Make the PanGestureHelper class less tightly tied into the library implementation, allowing its usage outside the library
- Fix the panning/scrolling logic in the library view to account for the album picker and the new custom footer view properly
  - Also, update the logic of the panning to take the direction of the gesture into account, allowing "canceling" the gesture properly
- Allow processing videos without PHAssets (for cases where we only have a file on the disk)