### PR TITLE
feat: Allow setting a max height for the asset preview

### DIFF
--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -172,6 +172,9 @@ class ExampleViewController: UIViewController {
         config.library.allowedMultiSelectionAspectRatioOverrides = overrides
         config.library.allowPhotoAndVideoSelection = true
 
+        /* Set a max height for the asset preview */
+        // config.library.assetPreviewMaxHeight = 280.0
+
         /* Disable scroll to change between mode */
         // config.isScrollToChangeModesEnabled = false
         // config.library.minNumberOfItems = 2

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -274,8 +274,12 @@ public struct YPConfigLibrary {
     public var allowPhotoAndVideoSelection : Bool = false
 
     /// A view you set here will be shown underneath the asset preview view in the library screen.
-    /// The view will be automatically laid out to fill the screen horizontally, but it should determine its own height. 
+    /// The view will be automatically laid out to fill the screen horizontally, but it should determine its own height.
     public var assetPreviewFooterView: UIView?
+
+    /// Set this value if you want to restrict the maximum height of the asset preview view
+    /// If not set, the asset preview will be a square.
+    public var assetPreviewMaxHeight: CGFloat?
 }
 
 /// Encapsulates video specific settings.

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -251,6 +251,7 @@ fileprivate extension YPAssetZoomableView {
 
     func getContainerSize(from size: CGSize) -> CGSize {
         let screenWidth = YPImagePickerConfiguration.screenWidth
+        let superviewFrameSize = self.superview?.frame.size ?? CGSize(width: screenWidth, height: screenWidth)
 
         let w = size.width
         let h = size.height
@@ -265,11 +266,13 @@ fileprivate extension YPAssetZoomableView {
             isAspectRatioOutOfRange = true
         }
         if aspectRatio > 1.0 { // Landscape
-            containerWidth = screenWidth
-            containerHeight = screenWidth / aspectRatio
+            let targetDimension = max(superviewFrameSize.width, superviewFrameSize.height)
+            containerWidth = targetDimension
+            containerHeight = targetDimension / aspectRatio
         } else if aspectRatio < 1.0 { // Portrait
-            containerWidth = screenWidth * aspectRatio
-            containerHeight = screenWidth
+            let targetDimension = min(superviewFrameSize.height, superviewFrameSize.width)
+            containerWidth = targetDimension * aspectRatio
+            containerHeight = targetDimension
 
             if let minWidth = minWidthForItem {
                 containerWidth = minWidth * aspectRatio
@@ -277,8 +280,9 @@ fileprivate extension YPAssetZoomableView {
             }
 
         } else { // Square
-            containerWidth = screenWidth
-            containerHeight = screenWidth
+            let targetDimension = min(superviewFrameSize.height, superviewFrameSize.width)
+            containerWidth = targetDimension
+            containerHeight = targetDimension
         }
 
         return CGSize(width: containerWidth, height: containerHeight)

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -255,7 +255,22 @@ internal final class YPLibraryView: UIView {
         line.height(1)
         line.fillHorizontally()
 
-        assetViewContainer.top(0).fillHorizontally().heightEqualsWidth()
+        assetViewContainer.top(0).fillHorizontally()
+        if let assetPreviewMaxHeight = YPConfig.library.assetPreviewMaxHeight {
+            let heightConstraint = NSLayoutConstraint(item: assetViewContainer, attribute: .height, relatedBy: .lessThanOrEqual, toItem: assetViewContainer, attribute: .width, multiplier: 1, constant: 0)
+            heightConstraint.priority = .defaultHigh
+            heightConstraint.isActive = true
+            assetViewContainer.addConstraint(heightConstraint)
+
+            let heightEqualsWidthConstraint = NSLayoutConstraint(item: assetViewContainer, attribute: .height, relatedBy: .equal, toItem: assetViewContainer, attribute: .width, multiplier: 1, constant: 0)
+            heightEqualsWidthConstraint.priority = .defaultLow
+            heightEqualsWidthConstraint.isActive = true
+            assetViewContainer.addConstraint(heightEqualsWidthConstraint)
+            (assetViewContainer.Height <= assetPreviewMaxHeight).priority = .required
+        } else {
+            assetViewContainer.heightEqualsWidth()
+        }
+
         self.assetViewContainerConstraintTop = assetViewContainer.topConstraint
         assetZoomableView.width(0)
         assetZoomableView.height(0)


### PR DESCRIPTION
This PR adds a new configuration variable: `assetPreviewMaxHeight`, which allows setting the maximum height of the asset preview element. If the configuration variable is not set, it will default to square like it used to. If it _is_ set, the height will be limited to the given value. This will allow giving more space to the gallery grid in situations where we're using a tall `assetPreviewFooterView`. 

Screenshots showing previews in different aspect ratios with max height set to 280.0:

| Image orientation |     Square  | Landscape  | Portrait  |
| -- | -- | -- | -- |
| Screenshots |  <img src="https://github.com/rewardStyle/YPImagePicker/assets/122308456/2f69795a-5e8e-4916-9344-f9e4d57cacb4" width="300" />  | <img src="https://github.com/rewardStyle/YPImagePicker/assets/122308456/e44805e1-d4ab-4463-b244-4cb340a5d662" width="300" />  | <img src="https://github.com/rewardStyle/YPImagePicker/assets/122308456/9eaff1c2-7985-4c54-b2ae-25a090f2b977" width="300" />  |


