### PR TITLE
Media Processing DataDog Observability Support

### DIFF
--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -364,7 +364,7 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
 
             // cropping and trimming simultaneously to reduce total transcoding time
 
-            let result: (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void = { [weak self] result in
+            let result: ProcessingResult = { [weak self] result in
                 DispatchQueue.main.async {
                     switch result {
                     case let .success(video):

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -372,7 +372,7 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
                 mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
             } else {
                 // TODO: Need to solve the IG flow here.
-                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, videoSize: CGSize(width: 0, height: 0), cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
+                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
             }
 
             // set up notification listener
@@ -554,8 +554,7 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
             if let videoAsset = inputVideo.asset {
                 mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, callback: callback)
             } else {
-                //IG FLOW NEED TO CONFIRM THIS BEHAVIOR
-                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, videoSize: CGSize(width: 0, height: 0), cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, callback: callback)
+                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, callback: callback)
             }
             return true
         } else {

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -547,24 +547,24 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
            startTime != coverTrimTimes?.startTime || endTime != coverTrimTimes?.endTime {
             let timerange = CMTimeRange(start: startTime, end: endTime)
 
-            let callback: (_ video: ProcessedVideo?) -> Void = { [weak self] video in
+            let result: (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void = { [weak self] result in
                 DispatchQueue.main.async {
-                    if let video {
-                        let trimmedAsset = AVAsset(url: video.fileUrl)
+                    switch result {
+                    case let .success(video):
+                        let trimmedAsset = AVAsset(url: video.videoUrl)
                         self?.setupGenerator(trimmedAsset)
                         self?.coverThumbSelectorView.asset = trimmedAsset
                         self?.coverTrimTimes = (startTime: startTime, endTime: endTime)
                         self?.generateCoverImageAtTime(startTime)
-                    } else {
+                    case let .failure(error):
                         ypLog("YPVideoFiltersVC -> Invalid asset url.")
-
                     }
                 }
             }
             if let videoAsset = inputVideo.asset {
-                mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, callback: callback)
+                mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, result: result)
             } else {
-                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, callback: callback)
+                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, result: result)
             }
             return true
         } else {

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -381,7 +381,6 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
                 videoProcessingDelegate?.willBeginVideoProcessing(assetIdentifier: videoAsset.localIdentifier)
                 mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
             } else {
-                // TODO: Need to solve the IG flow here.
                 videoProcessingDelegate?.willBeginVideoProcessing(assetIdentifier: inputVideo.url.absoluteString)
                 mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
             }

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -364,13 +364,13 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
 
             // cropping and trimming simultaneously to reduce total transcoding time
 
-            let callback: (_ video: ProcessedVideo?) -> Void = { [weak self] video in
+            let result: (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void = { [weak self] result in
                 DispatchQueue.main.async {
-                    if let video {
+                    switch result {
+                    case let .success(video):
                         self?.videoProcessingDelegate?.didCompleteVideoProcessing(processedVideo: video)
-
-                        self?.completeSave(thumbnail: self?.croppedImage ?? UIImage(), videoUrl: video.fileUrl, asset: self?.inputVideo.asset, timeRange: timeRange)
-                    } else {
+                        self?.completeSave(thumbnail: self?.croppedImage ?? UIImage(), videoUrl: video.videoUrl, asset: self?.inputVideo.asset, timeRange: timeRange)
+                    case let .failure(error):
                         ypLog("YPVideoFiltersVC -> Invalid asset url.")
                         self?.resetView()
                     }
@@ -379,10 +379,10 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
 
             if let videoAsset = inputVideo.asset {
                 videoProcessingDelegate?.willBeginVideoProcessing(assetIdentifier: videoAsset.localIdentifier)
-                mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
+                mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, result: result)
             } else {
                 videoProcessingDelegate?.willBeginVideoProcessing(assetIdentifier: inputVideo.url.absoluteString)
-                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
+                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, result: result)
             }
 
             // set up notification listener

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -356,10 +356,10 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
 
             // cropping and trimming simultaneously to reduce total transcoding time
 
-            let callback: (_ videoURL: URL?) -> Void = { [weak self] (url) in
+            let callback: (_ video: LibraryMediaManager.ProcessedVideo?) -> Void = { [weak self] video in
                 DispatchQueue.main.async {
-                    if let url = url {
-                        self?.completeSave(thumbnail: self?.croppedImage ?? UIImage(), videoUrl: url, asset: self?.inputVideo.asset, timeRange: timeRange)
+                    if let video {
+                        self?.completeSave(thumbnail: self?.croppedImage ?? UIImage(), videoUrl: video.fileUrl, asset: self?.inputVideo.asset, timeRange: timeRange)
                     } else {
                         ypLog("YPVideoFiltersVC -> Invalid asset url.")
                         self?.resetView()
@@ -370,7 +370,8 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
             if let videoAsset = inputVideo.asset {
                 mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
             } else {
-                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
+                // TODO: Need to solve the IG flow here.
+                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, videoSize: CGSize(width: 0, height: 0), cropRect: inputVideo.cropRect!, timeRange: timeRange, shouldMute: shouldMute, callback: callback)
             }
 
             // set up notification listener
@@ -535,10 +536,10 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
            startTime != coverTrimTimes?.startTime || endTime != coverTrimTimes?.endTime {
             let timerange = CMTimeRange(start: startTime, end: endTime)
 
-            let callback: (_ videoURL: URL?) -> Void = { [weak self] (url) in
+            let callback: (_ video: LibraryMediaManager.ProcessedVideo?) -> Void = { [weak self] video in
                 DispatchQueue.main.async {
-                    if let url = url {
-                        let trimmedAsset = AVAsset(url: url)
+                    if let video {
+                        let trimmedAsset = AVAsset(url: video.fileUrl)
                         self?.setupGenerator(trimmedAsset)
                         self?.coverThumbSelectorView.asset = trimmedAsset
                         self?.coverTrimTimes = (startTime: startTime, endTime: endTime)
@@ -552,7 +553,8 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
             if let videoAsset = inputVideo.asset {
                 mediaManager.fetchVideoUrlAndCrop(for: videoAsset, cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, callback: callback)
             } else {
-                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, callback: callback)
+                //IG FLOW NEED TO CONFIRM THIS BEHAVIOR
+                mediaManager.fetchVideoUrlAndCrop(for: inputVideo.url, videoSize: CGSize(width: 0, height: 0), cropRect: inputVideo.cropRect!, timeRange: timerange, shouldMute: false, compressionTypeOverride: AVAssetExportPresetPassthrough, callback: callback)
             }
             return true
         } else {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -207,17 +207,17 @@ open class LibraryMediaManager {
                 callback(nil)
                 return
             }
-            self.fetchVideoUrlAndCrop(for: asset, videoSize: CGSize(width: videoAsset.pixelWidth, height: videoAsset.pixelHeight), assetIdentifier: videoAsset.localIdentifier, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionTypeOverride, processingFailedRetryCount: processingFailedRetryCount, isSlowMoVideo: isSlowMoVideo, callback: callback)
+            self.fetchVideoUrlAndCrop(for: asset, assetIdentifier: videoAsset.localIdentifier, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionTypeOverride, processingFailedRetryCount: processingFailedRetryCount, isSlowMoVideo: isSlowMoVideo, callback: callback)
         }
     }
 
-    open func fetchVideoUrlAndCrop(for videoUrl: URL, videoSize: CGSize, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, callback: @escaping (_ video: ProcessedVideo?) -> Void) {
+    open func fetchVideoUrlAndCrop(for videoUrl: URL, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, callback: @escaping (_ video: ProcessedVideo?) -> Void) {
         let asset = AVAsset(url: videoUrl)
-        self.fetchVideoUrlAndCrop(for: asset, videoSize: videoSize, assetIdentifier: videoUrl.absoluteString, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionTypeOverride, processingFailedRetryCount: processingFailedRetryCount, isSlowMoVideo: false, callback: callback)
+        self.fetchVideoUrlAndCrop(for: asset, assetIdentifier: videoUrl.absoluteString, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionTypeOverride, processingFailedRetryCount: processingFailedRetryCount, isSlowMoVideo: false, callback: callback)
     }
 
 
-    private func fetchVideoUrlAndCrop(for videoAsset: AVAsset, videoSize: CGSize, assetIdentifier: String, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, isSlowMoVideo: Bool = false, callback: @escaping (_ video: ProcessedVideo?) -> Void) {
+    private func fetchVideoUrlAndCrop(for videoAsset: AVAsset, assetIdentifier: String, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, isSlowMoVideo: Bool = false, callback: @escaping (_ video: ProcessedVideo?) -> Void) {
 
         let assetComposition = AVMutableComposition()
         let trackTimeRange = timeRange
@@ -339,7 +339,7 @@ open class LibraryMediaManager {
                             if retryCount > 1 {
                                 callback(nil)
                             } else {
-                                self.fetchVideoUrlAndCrop(for: videoAsset, videoSize: videoSize, assetIdentifier: assetIdentifier, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionOverride, processingFailedRetryCount: retryCount, isSlowMoVideo: isSlowMoVideo, callback: callback)
+                                self.fetchVideoUrlAndCrop(for: videoAsset, assetIdentifier: assetIdentifier, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionOverride, processingFailedRetryCount: retryCount, isSlowMoVideo: isSlowMoVideo, callback: callback)
                             }
                         } else {
                             callback(nil)

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -27,6 +27,14 @@ open class LibraryMediaManager {
         public let originalWidth: Int
         public let originalHeight: Int
         public let totalVideoDuration: TimeInterval
+
+        public init(assetIdentifier: String, fileUrl: URL, originalWidth: Int, originalHeight: Int, totalVideoDuration: TimeInterval) {
+            self.assetIdentifier = assetIdentifier
+            self.fileUrl = fileUrl
+            self.originalWidth = abs(originalWidth)
+            self.originalHeight = abs(originalHeight)
+            self.totalVideoDuration = totalVideoDuration
+        }
     }
 
     weak var v: YPLibraryView?

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -267,10 +267,10 @@ open class LibraryMediaManager {
 
     open func fetchVideoUrlAndCrop(for videoUrl: URL, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, result: @escaping ProcessingResult) {
         let asset = AVAsset(url: videoUrl)
-        self.fetchVideoUrlAndCrop(for: asset, videoUrl: videoUrl, assetIdentifier: videoUrl.absoluteString, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionTypeOverride, processingFailedRetryCount: processingFailedRetryCount, isSlowMoVideo: false, result: result)
+        self.fetchVideoUrlAndCrop(for: asset, assetIdentifier: videoUrl.absoluteString, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionTypeOverride, processingFailedRetryCount: processingFailedRetryCount, isSlowMoVideo: false, result: result)
     }
 
-    private func fetchVideoUrlAndCrop(for videoAsset: AVAsset, videoUrl: URL? = nil, assetIdentifier: String, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, isSlowMoVideo: Bool = false, result: @escaping ProcessingResult) {
+    private func fetchVideoUrlAndCrop(for videoAsset: AVAsset, assetIdentifier: String, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, isSlowMoVideo: Bool = false, result: @escaping ProcessingResult) {
 
         let assetComposition = AVMutableComposition()
         let trackTimeRange = timeRange

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -17,14 +17,14 @@ extension Notification.Name {
 
 public struct ProcessedVideo {
     public let assetIdentifier: String
-    public let fileUrl: URL
+    public let videoUrl: URL
     public let originalWidth: Int
     public let originalHeight: Int
     public let totalVideoDuration: TimeInterval
 
-    public init(assetIdentifier: String, fileUrl: URL, originalWidth: Int, originalHeight: Int, totalVideoDuration: TimeInterval) {
+    public init(assetIdentifier: String, videoUrl: URL, originalWidth: Int, originalHeight: Int, totalVideoDuration: TimeInterval) {
         self.assetIdentifier = assetIdentifier
-        self.fileUrl = fileUrl
+        self.videoUrl = videoUrl
         self.originalWidth = abs(originalWidth)
         self.originalHeight = abs(originalHeight)
         self.totalVideoDuration = totalVideoDuration.rounded()
@@ -37,6 +37,13 @@ public struct ProcessedVideo {
             "durationSeconds": String(totalVideoDuration)
         ]
     }
+}
+
+public enum LibraryMediaManagerError: Error {
+    case processingFailed(message: String)
+    case retryLimitReached(message: String)
+    case unknown(message: String)
+    case assetNotFound(message: String)
 }
 
 open class LibraryMediaManager {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -15,26 +15,34 @@ extension Notification.Name {
     public static var LibraryMediaManagerExportProgressUpdate: Notification.Name { return .init(rawValue: "\(namespace).LibraryMediaManagerExportProgressUpdate") }
 }
 
+public struct ProcessedVideo {
+    public let assetIdentifier: String
+    public let fileUrl: URL
+    public let originalWidth: Int
+    public let originalHeight: Int
+    public let totalVideoDuration: TimeInterval
+
+    public init(assetIdentifier: String, fileUrl: URL, originalWidth: Int, originalHeight: Int, totalVideoDuration: TimeInterval) {
+        self.assetIdentifier = assetIdentifier
+        self.fileUrl = fileUrl
+        self.originalWidth = abs(originalWidth)
+        self.originalHeight = abs(originalHeight)
+        self.totalVideoDuration = totalVideoDuration.rounded()
+    }
+
+    public var trackingTags: [String: String] {
+        [
+            "width": String(originalWidth),
+            "height": String(originalHeight),
+            "durationSeconds": String(totalVideoDuration)
+        ]
+    }
+}
+
 open class LibraryMediaManager {
     struct ExportData {
         let localIdentifier: String
         let session: AVAssetExportSession
-    }
-
-    public struct ProcessedVideo {
-        public let assetIdentifier: String
-        public let fileUrl: URL
-        public let originalWidth: Int
-        public let originalHeight: Int
-        public let totalVideoDuration: TimeInterval
-
-        public init(assetIdentifier: String, fileUrl: URL, originalWidth: Int, originalHeight: Int, totalVideoDuration: TimeInterval) {
-            self.assetIdentifier = assetIdentifier
-            self.fileUrl = fileUrl
-            self.originalWidth = abs(originalWidth)
-            self.originalHeight = abs(originalHeight)
-            self.totalVideoDuration = totalVideoDuration
-        }
     }
 
     weak var v: YPLibraryView?

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -29,15 +29,9 @@ public struct ProcessedVideo {
         self.originalHeight = abs(originalHeight)
         self.totalVideoDuration = totalVideoDuration.rounded()
     }
-
-    public var trackingTags: [String: String] {
-        [
-            "width": String(originalWidth),
-            "height": String(originalHeight),
-            "durationSeconds": String(totalVideoDuration)
-        ]
-    }
 }
+
+public typealias ProcessingResult = (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void
 
 public enum LibraryMediaManagerError: Error {
     case processingFailed(message: String)
@@ -168,7 +162,7 @@ open class LibraryMediaManager {
     /// - Parameters:
     ///   - videoAsset: PHAsset which url is requested
     ///   - result: Returns the video metadata
-    func fetchVideoUrl(for videoAsset: PHAsset, result: @escaping (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void) {
+    func fetchVideoUrl(for videoAsset: PHAsset, result: @escaping ProcessingResult) {
         let videosOptions = PHVideoRequestOptions()
         videosOptions.isNetworkAccessAllowed = true
         videosOptions.deliveryMode = .highQualityFormat
@@ -223,7 +217,7 @@ open class LibraryMediaManager {
         }
     }
 
-    open func fetchVideoUrlAndCrop(for videoAsset: PHAsset, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, result: @escaping (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void) {
+    open func fetchVideoUrlAndCrop(for videoAsset: PHAsset, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, result: @escaping ProcessingResult) {
         let videosOptions = PHVideoRequestOptions()
         videosOptions.isNetworkAccessAllowed = true
         videosOptions.deliveryMode = .highQualityFormat
@@ -238,12 +232,12 @@ open class LibraryMediaManager {
         }
     }
 
-    open func fetchVideoUrlAndCrop(for videoUrl: URL, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, result: @escaping (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void) {
+    open func fetchVideoUrlAndCrop(for videoUrl: URL, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, result: @escaping ProcessingResult) {
         let asset = AVAsset(url: videoUrl)
         self.fetchVideoUrlAndCrop(for: asset, videoUrl: videoUrl, assetIdentifier: videoUrl.absoluteString, cropRect: cropRect, timeRange: timeRange, shouldMute: shouldMute, compressionTypeOverride: compressionTypeOverride, processingFailedRetryCount: processingFailedRetryCount, isSlowMoVideo: false, result: result)
     }
 
-    private func fetchVideoUrlAndCrop(for videoAsset: AVAsset, videoUrl: URL? = nil, assetIdentifier: String, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, isSlowMoVideo: Bool = false, result: @escaping (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void) {
+    private func fetchVideoUrlAndCrop(for videoAsset: AVAsset, videoUrl: URL? = nil, assetIdentifier: String, cropRect: CGRect, timeRange: CMTimeRange = CMTimeRange(start: CMTime.zero, end: CMTime.zero), shouldMute: Bool = false, compressionTypeOverride: String? = nil, processingFailedRetryCount: Int = 0, isSlowMoVideo: Bool = false, result: @escaping ProcessingResult) {
 
         let assetComposition = AVMutableComposition()
         let trackTimeRange = timeRange

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -450,7 +450,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
 
     private func checkVideoLengthAndCrop(for asset: PHAsset,
                                          withCropRect: CGRect? = nil,
-                                         callback: @escaping (_ videoURL: URL?) -> Void) {
+                                         callback: @escaping (_ video: LibraryMediaManager.ProcessedVideo?) -> Void) {
         if fitsVideoLengthLimits(asset: asset) == true {
             delegate?.libraryViewDidTapNext()
             let normalizedCropRect = withCropRect ?? DispatchQueue.main.sync { v.currentCropRect() }
@@ -470,7 +470,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
 
     private func checkVideoLengthAndFetch(for asset: PHAsset,
-                                          callback: @escaping (_ videoURL: URL?) -> Void) {
+                                          callback: @escaping (_ video: LibraryMediaManager.ProcessedVideo?) -> Void) {
         if fitsVideoLengthLimits(asset: asset) == true {
             delegate?.libraryViewDidTapNext()
             mediaManager.fetchVideoUrl(for: asset, callback: callback)
@@ -516,10 +516,10 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                             }
 
                         case .video:
-                            self.checkVideoLengthAndCrop(for: asset.asset, withCropRect: asset.cropRect) { videoURL in
-                                if let videoURL = videoURL {
-                                    let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
-                                                                 videoURL: videoURL, asset: asset.asset)
+                            self.checkVideoLengthAndCrop(for: asset.asset, withCropRect: asset.cropRect) { video in
+                                if let video {
+                                    let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(video.fileUrl),
+                                                                 videoURL: video.fileUrl, asset: asset.asset)
                                     videoItem.cropRect = self.getCropRect(for: asset.asset, cropRect: self.selectedItems[index].cropRect)
                                     resultMediaItems[index] = YPMediaItem.video(v: videoItem)
                                 } else {
@@ -542,13 +542,13 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     case .audio, .unknown:
                         return
                     case .video:
-                        self.checkVideoLengthAndFetch(for: asset, callback: { videoURL in
+                        self.checkVideoLengthAndFetch(for: asset, callback: { video in
                             DispatchQueue.main.async {
                                 self.delegate?.libraryViewFinishedLoading() // reset UI regardless if a video url is returned
 
-                                if let videoURL = videoURL {
-                                    let video = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
-                                                             videoURL: videoURL, asset: asset)
+                                if let processedVideo = video {
+                                    let video = YPMediaVideo(thumbnail: thumbnailFromVideoPath(processedVideo.fileUrl),
+                                                             videoURL: processedVideo.fileUrl, asset: asset)
 
                                     video.cropRect = self.getCropRect(for: asset)
                                     videoCallback(video)

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -450,7 +450,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
 
     private func checkVideoLengthAndCrop(for asset: PHAsset,
                                          withCropRect: CGRect? = nil,
-                                         callback: @escaping (_ video: ProcessedVideo?) -> Void) {
+                                         result: @escaping (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void) {
         if fitsVideoLengthLimits(asset: asset) == true {
             delegate?.libraryViewDidTapNext()
             let normalizedCropRect = withCropRect ?? DispatchQueue.main.sync { v.currentCropRect() }
@@ -462,18 +462,18 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                                         width: ts.width,
                                         height: ts.height)
             if !YPImagePickerConfiguration.shared.library.allowPhotoAndVideoSelection {
-                mediaManager.fetchVideoUrlAndCrop(for: asset, cropRect: resultCropRect, callback: callback)
+                mediaManager.fetchVideoUrlAndCrop(for: asset, cropRect: resultCropRect, result: result)
             } else {
-                mediaManager.fetchVideoUrl(for: asset, callback: callback)
+                mediaManager.fetchVideoUrl(for: asset, result: result)
             }
         }
     }
 
     private func checkVideoLengthAndFetch(for asset: PHAsset,
-                                          callback: @escaping (_ video: ProcessedVideo?) -> Void) {
+                                          result: @escaping (Result<ProcessedVideo, LibraryMediaManagerError>) -> Void) {
         if fitsVideoLengthLimits(asset: asset) == true {
             delegate?.libraryViewDidTapNext()
-            mediaManager.fetchVideoUrl(for: asset, callback: callback)
+            mediaManager.fetchVideoUrl(for: asset, result: result)
         }
     }
     
@@ -516,13 +516,14 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                             }
 
                         case .video:
-                            self.checkVideoLengthAndCrop(for: asset.asset, withCropRect: asset.cropRect) { video in
-                                if let video {
-                                    let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(video.fileUrl),
-                                                                 videoURL: video.fileUrl, asset: asset.asset)
+                            self.checkVideoLengthAndCrop(for: asset.asset, withCropRect: asset.cropRect) { result in
+                                switch result {
+                                case let .success(video):
+                                    let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(video.videoUrl),
+                                                                 videoURL: video.videoUrl, asset: asset.asset)
                                     videoItem.cropRect = self.getCropRect(for: asset.asset, cropRect: self.selectedItems[index].cropRect)
                                     resultMediaItems[index] = YPMediaItem.video(v: videoItem)
-                                } else {
+                                case let .failure(error):
                                     ypLog("YPLibraryVC -> selectedMedia -> Problems with fetching videoURL.")
                                 }
                                 asyncGroup.leave()
@@ -542,21 +543,20 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     case .audio, .unknown:
                         return
                     case .video:
-                        self.checkVideoLengthAndFetch(for: asset, callback: { video in
+                        self.checkVideoLengthAndFetch(for: asset) { result in
                             DispatchQueue.main.async {
                                 self.delegate?.libraryViewFinishedLoading() // reset UI regardless if a video url is returned
-
-                                if let processedVideo = video {
-                                    let video = YPMediaVideo(thumbnail: thumbnailFromVideoPath(processedVideo.fileUrl),
-                                                             videoURL: processedVideo.fileUrl, asset: asset)
-
+                                switch result {
+                                case let .success(video):
+                                    let video = YPMediaVideo(thumbnail: thumbnailFromVideoPath(video.videoUrl),
+                                                             videoURL: video.videoUrl, asset: asset)
                                     video.cropRect = self.getCropRect(for: asset)
                                     videoCallback(video)
-                                } else {
+                                case let .failure(error):
                                     ypLog("YPLibraryVC -> selectedMedia -> Problems with fetching videoURL.")
                                 }
                             }
-                        })
+                        }
 
 
                     case .image:

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -450,7 +450,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
 
     private func checkVideoLengthAndCrop(for asset: PHAsset,
                                          withCropRect: CGRect? = nil,
-                                         callback: @escaping (_ video: LibraryMediaManager.ProcessedVideo?) -> Void) {
+                                         callback: @escaping (_ video: ProcessedVideo?) -> Void) {
         if fitsVideoLengthLimits(asset: asset) == true {
             delegate?.libraryViewDidTapNext()
             let normalizedCropRect = withCropRect ?? DispatchQueue.main.sync { v.currentCropRect() }
@@ -470,7 +470,7 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
 
     private func checkVideoLengthAndFetch(for asset: PHAsset,
-                                          callback: @escaping (_ video: LibraryMediaManager.ProcessedVideo?) -> Void) {
+                                          callback: @escaping (_ video: ProcessedVideo?) -> Void) {
         if fitsVideoLengthLimits(asset: asset) == true {
             delegate?.libraryViewDidTapNext()
             mediaManager.fetchVideoUrl(for: asset, callback: callback)


### PR DESCRIPTION
This PR adds supporting changes to be able to provide enough information so that the client app can send video processing information to DataDog. Each video that completes processing will provide the following information to the client:
- video height
- video width 
- video duration
- URL to where the video is
- a unique identifier (This can be either the `PHAsset localIdentifier or the remote URL in the case of IG uploads)

Changes were made to that both the single video flows + storytelling video flows can provide all the information the client needs to send through to DataDog.