### PR TITLE
feat: [Creator] Add Ability To Fetch All Media And Sort Reversed [CC-1916]

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -216,6 +216,10 @@ public struct YPConfigLibrary {
     
     public var maxAspectRatio: CGFloat?
 
+    /// Pre-selects all of the media and sorts it in a way to closely
+    /// resemble the 'Recents' album.
+    public var shouldPreselectRecentsAlbum: Bool = false
+
     /// List of aspect ratios allowed for videos (when selecting a single video)
     /// The gallery will auto-crop the media to the closest aspect ratio from this list (without letterboxing)
     public var allowedVideoAspectRatios: [CGFloat]?

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -216,8 +216,10 @@ public struct YPConfigLibrary {
     
     public var maxAspectRatio: CGFloat?
 
-    /// Pre-selects all of the media and sorts it in a way to closely
-    /// resemble the 'Recents' album.
+    /// Pre-selects all of the smart album media when entering the media picker
+    /// and renders the media in reverse order. This configuration option will
+    /// override any fetch options supplied from `YPConfig.library.options` and
+    /// will override the default fetch options which orders media by `creationDate`
     public var shouldPreselectRecentsAlbum: Bool = false
 
     /// List of aspect ratios allowed for videos (when selecting a single video)

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -444,8 +444,12 @@ open class LibraryMediaManager {
 
         // If pre-selecting the recents album the sorting is applied in reverse. This closely matches the 'Recents' album in Photos. This
         // should only apply if the user has not manually selected a collection.
-        if YPConfig.library.shouldPreselectRecentsAlbum, collection == nil {
-            return fetchResult[fetchResult.count - index - 1]
+        if YPConfig.library.shouldPreselectRecentsAlbum {
+            if collection == nil || isSelectedCollectionRecentsAlbum() {
+                return fetchResult[fetchResult.count - index - 1]
+            }  else {
+                return fetchResult.object(at: index)
+            }
         } else {
             return fetchResult.object(at: index)
         }

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -451,6 +451,11 @@ open class LibraryMediaManager {
         }
     }
 
+    func isSelectedCollectionRecentsAlbum() -> Bool {
+        guard let collection else { return false }
+        return collection.assetCollectionType == .smartAlbum && collection.assetCollectionSubtype == .smartAlbumUserLibrary
+    }
+
     func getFirstImageAsset() -> (asset: PHAsset?, index: Int?) {
         guard let fetchResult else { return (nil, nil) }
         var imageAsset: PHAsset?

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -441,7 +441,9 @@ open class LibraryMediaManager {
             ypLog("FetchResult not contain this index: \(index)")
             return nil
         }
-        return fetchResult.object(at: index)
+
+        // If pre-selecting the recents album the sorting is applied in reverse. This closely matches the 'Recents' album in Photos.
+        return YPConfig.library.shouldPreselectRecentsAlbum ? fetchResult[fetchResult.count - index - 1] : fetchResult.object(at: index)
     }
 
     func getFirstImageAsset() -> (asset: PHAsset?, index: Int?) {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -442,8 +442,13 @@ open class LibraryMediaManager {
             return nil
         }
 
-        // If pre-selecting the recents album the sorting is applied in reverse. This closely matches the 'Recents' album in Photos.
-        return YPConfig.library.shouldPreselectRecentsAlbum ? fetchResult[fetchResult.count - index - 1] : fetchResult.object(at: index)
+        // If pre-selecting the recents album the sorting is applied in reverse. This closely matches the 'Recents' album in Photos. This
+        // should only apply if the user has not manually selected a collection.
+        if YPConfig.library.shouldPreselectRecentsAlbum, collection == nil {
+            return fetchResult[fetchResult.count - index - 1]
+        } else {
+            return fetchResult.object(at: index)
+        }
     }
 
     func getFirstImageAsset() -> (asset: PHAsset?, index: Int?) {

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -450,7 +450,6 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     // MARK: - Fetching Media
 
     func fetchAllMedia() -> PHAssetCollection? {
-        let fetchOptions = PHFetchOptions()
         let collections = PHAssetCollection.fetchAssetCollections(
             with: .smartAlbum,
             subtype: .any,

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -265,7 +265,12 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     func refreshMediaRequest() {
         let options = buildPHFetchOptions()
 
-        if let collection = mediaManager.collection {
+        if  YPConfig.library.shouldPreselectRecentsAlbum,
+            mediaManager.collection == nil,
+            let allMediaAlbum = fetchAllMedia()
+        {
+            mediaManager.fetchResult = PHAsset.fetchAssets(in: allMediaAlbum, options: nil)
+        } else if let collection = mediaManager.collection {
             mediaManager.fetchResult = PHAsset.fetchAssets(in: collection, options: options)
         } else {
             mediaManager.fetchResult = PHAsset.fetchAssets(with: options)
@@ -433,7 +438,17 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
     
     // MARK: - Fetching Media
-    
+
+    func fetchAllMedia() -> PHAssetCollection? {
+        let fetchOptions = PHFetchOptions()
+        let collections = PHAssetCollection.fetchAssetCollections(
+            with: .smartAlbum,
+            subtype: .any,
+            options: nil
+        )
+        return collections.firstObject
+    }
+
     private func fetchImageAndCrop(for asset: PHAsset,
                                    withCropRect: CGRect? = nil,
                                    callback: @escaping (_ photo: UIImage, _ exif: [String: Any]) -> Void) {


### PR DESCRIPTION
[CC-1916](https://rewardstyle.atlassian.net/browse/CC-1916)

This PR adds a new `YPConfig` property: `shouldPreselectRecentsAlbum` which when true will display all media in a similar way the "Recents" album does in Photos. Essentially this takes all of the media from all smart albums and sorts them in inverse order so that the most recently added content appears on the top of the list instead of sorting the media by `creationDate` as the current implementation does. 

This functionality will be behind a new feature flag on the client that toggles this `YPConfig` property. 

A couple of details on the flows touched:

- The initial load of the image picker which shows all media sorted in inverse order
- Opening the albums picker and manually selecting "Recents" album persists this ordering.
- Selecting any smart album that is not "Recents"  or any other user created album **does not apply this ordering, and instead applies the default ordering.**
- When this `YPConfig` option is disabled then the regular ordering by `creationDate` is used.

[CC-1916]: https://rewardstyle.atlassian.net/browse/CC-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ