### PR TITLE
fix: When using preferredTransform, use abs to prevent negative sizes

### DIFF
--- a/Source/Filters/Photo/YPCoverImageView.swift
+++ b/Source/Filters/Photo/YPCoverImageView.swift
@@ -53,7 +53,8 @@ public class YPCoverImageView: YPAdjustableView {
             let videoAsset = AVAsset(url: videoUrl)
             guard let track = videoAsset.tracks(withMediaType: AVMediaType.video).first else { return }
             let size = track.naturalSize.applying(track.preferredTransform)
-            adjustViewFrameIfNeeded(cropRect: cropRect, assetSize: size, targetAspectRatio: targetAspectRatio)
+            let fixedSize = CGSize(width: abs(size.width), height: abs(size.height))
+            adjustViewFrameIfNeeded(cropRect: cropRect, assetSize: fixedSize, targetAspectRatio: targetAspectRatio)
         }
     }
 

--- a/Source/Filters/Video/YPVideoView.swift
+++ b/Source/Filters/Video/YPVideoView.swift
@@ -60,7 +60,8 @@ public class YPVideoView: YPAdjustableView {
             let videoAsset = AVAsset(url: videoUrl)
             guard let track = videoAsset.tracks(withMediaType: AVMediaType.video).first else { return }
             let size = track.naturalSize.applying(track.preferredTransform)
-            adjustViewFrameIfNeeded(cropRect: cropRect, assetSize: size, targetAspectRatio: targetAspectRatio)
+            let fixedSize = CGSize(width: abs(size.width), height: abs(size.height))
+            adjustViewFrameIfNeeded(cropRect: cropRect, assetSize: fixedSize, targetAspectRatio: targetAspectRatio)
         }
     }
 


### PR DESCRIPTION
Just a small fix for some cases where the `preferredTransform` of a video causes negative values for the `size`. Now, we'll always use positive values for the video size when showing the video on the trim or cover selection screens. 