### PR TITLE
fix: Fix Cover Photo Image Generation After Backgrounding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/rewardStyle/PryntTrimmerView",
-            .exact("4.0.3")
+            .exact("4.0.4")
         )
 
     ],

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -142,6 +142,15 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
                          selector: #selector(itemDidFinishPlaying(_:)),
                          name: .AVPlayerItemDidPlayToEndTime,
                          object: videoView.player.currentItem)
+        NotificationCenter.default
+            .addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            self.setupGenerator(inputAsset)
+        }
 
         videoView.clipsToBounds = true
         coverImageView.clipsToBounds = true

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -54,6 +54,7 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
     public var shouldShowDone = false
     public weak var videoProcessingDelegate: YPVideoProcessingDelegate?
     public var isUsingCustomCoverImage = false
+    public var customCoverImageReplacedHandler: (() -> Void)?
 
     var coverImageTime: CMTime?
     var coverTrimTimes: (startTime: CMTime, endTime: CMTime)?
@@ -551,6 +552,8 @@ open class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
                 self?.imageGenerator?.cancelAllCGImageGeneration()
                 self?.coverImageView.image = UIImage(cgImage: image)
                 self?.coverImageTime = time
+                self?.isUsingCustomCoverImage = false
+                self?.customCoverImageReplacedHandler?()
             }
         })
     }
@@ -627,6 +630,7 @@ extension YPVideoFiltersVC: YPTimeStampTrimmerViewDelegate {
 // MARK: - ThumbSelectorViewDelegate
 extension YPVideoFiltersVC: ThumbSelectorViewDelegate {
     public func didChangeThumbPosition(_ imageTime: CMTime) {
+        coverThumbSelectorView.resetThumbViewBorderColor()
         // fetch new image
         if !isUsingCustomCoverImage || vcType == .Cover {
             generateCoverImageAtTime(imageTime)

--- a/YPImagePicker.xcodeproj/project.pbxproj
+++ b/YPImagePicker.xcodeproj/project.pbxproj
@@ -1373,7 +1373,7 @@
 			repositoryURL = "https://github.com/rewardstyle/prynttrimmerview";
 			requirement = {
 				kind = exactVersion;
-				version = 4.0.3;
+				version = 4.0.4;
 			};
 		};
 		EBA37BCB26F75BCC005DAAD4 /* XCRemoteSwiftPackageReference "Stevia" */ = {

--- a/YPImagePicker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/YPImagePicker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rewardstyle/prynttrimmerview",
       "state" : {
-        "revision" : "267a4b08213af5d8803e849c6ba7399928628752",
-        "version" : "4.0.3"
+        "revision" : "59379933130df86e35b6f6a60aefa7262368854a",
+        "version" : "4.0.4"
       }
     },
     {


### PR DESCRIPTION
Cover photo image generation was breaking after locking device or backgrounding the app. This only seemed to happen when testing on device and didn't occur on simulator. This PR sets up the generator again after coming back into the foreground.