### PR TITLE
fix: Know When Cover Photo Is Changed When In Cover Only Selection Mode

### DIFF
--- a/Source/Filters/Photo/YPPhotoFiltersVC.swift
+++ b/Source/Filters/Photo/YPPhotoFiltersVC.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol IsMediaFilterVC: AnyObject {
-    var didSave: ((YPMediaItem) -> Void)? { get set }
+    var didSave: ((YPMediaItem, Bool) -> Void)? { get set }
     var didCancel: (() -> Void)? { get set }
 }
 
@@ -25,7 +25,7 @@ open class YPPhotoFiltersVC: UIViewController, IsMediaFilterVC, UIGestureRecogni
     public var inputPhoto: YPMediaPhoto!
     public var isFromSelectionVC = false
 
-    public var didSave: ((YPMediaItem) -> Void)?
+    public var didSave: ((YPMediaItem, Bool) -> Void)?
     public var didCancel: (() -> Void)?
 
     fileprivate let filters: [YPFilter] = YPConfig.filters
@@ -162,7 +162,7 @@ open class YPPhotoFiltersVC: UIViewController, IsMediaFilterVC, UIGestureRecogni
                 self.inputPhoto.modifiedImage = nil
             }
             DispatchQueue.main.async {
-                didSave(YPMediaItem.photo(p: self.inputPhoto))
+                didSave(YPMediaItem.photo(p: self.inputPhoto), false)
                 self.setupRightBarButton()
             }
         }

--- a/Source/SelectionsGallery/YPSelectionsGalleryVC.swift
+++ b/Source/SelectionsGallery/YPSelectionsGalleryVC.swift
@@ -119,7 +119,7 @@ extension YPSelectionsGalleryVC: UICollectionViewDelegate {
             }
         }
         
-        mediaFilterVC?.didSave = { outputMedia in
+        mediaFilterVC?.didSave = { outputMedia, _ in
             self.items[indexPath.row] = outputMedia
             collectionView.reloadData()
             self.dismiss(animated: true, completion: nil)

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -132,7 +132,7 @@ open class YPImagePicker: UINavigationController {
                     let filterVC = YPPhotoFiltersVC(inputPhoto: photo,
                                                     isFromSelectionVC: false)
                     // Show filters and then crop
-                    filterVC.didSave = { outputMedia in
+                    filterVC.didSave = { outputMedia, _ in
                         if case let YPMediaItem.photo(outputPhoto) = outputMedia {
                             showCropVC(photo: outputPhoto, completion: completion)
                         }
@@ -146,7 +146,7 @@ open class YPImagePicker: UINavigationController {
                     let videoFiltersVC = YPVideoFiltersVC.initWith(video: video,
                                                                    isFromSelectionVC: false,
                                                                    type:.Trimmer)
-                    videoFiltersVC.didSave = { [weak self] outputMedia in
+                    videoFiltersVC.didSave = { [weak self] outputMedia, _ in
                         let media = [outputMedia]
                         
                         if let video = media.singleVideo {                            
@@ -154,7 +154,7 @@ open class YPImagePicker: UINavigationController {
                             let videoFiltersVC = YPVideoFiltersVC.initWith(video: video,
                                                                            isFromSelectionVC: false,
                                                                            type: .Cover)
-                            videoFiltersVC.didSave = { [weak self] outputMedia in
+                            videoFiltersVC.didSave = { [weak self] outputMedia, _ in
                                 self?.didSelect(items: [outputMedia])
                             }
                             self?.pushViewController(videoFiltersVC, animated: true)


### PR DESCRIPTION
Supporting PR that allows the client to know when a cover photo has been changed for single video when the UI only allows for the cover photo to be changed.