### PR TITLE
CC-2396: Allow setting target aspect ratio for ThumbSelectorView

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/rewardStyle/PryntTrimmerView",
-            .exact("4.0.4")
+            .branch("CC-2396-cover-photo-aspect-ratio")
         )
 
     ],

--- a/YPImagePicker.xcodeproj/project.pbxproj
+++ b/YPImagePicker.xcodeproj/project.pbxproj
@@ -1372,8 +1372,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rewardstyle/prynttrimmerview";
 			requirement = {
-				kind = exactVersion;
-				version = 4.0.4;
+				branch = "CC-2396-cover-photo-aspect-ratio";
+				kind = branch;
 			};
 		};
 		EBA37BCB26F75BCC005DAAD4 /* XCRemoteSwiftPackageReference "Stevia" */ = {

--- a/YPImagePicker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/YPImagePicker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "8912ab1292b9d3d31c7f530c0914a7736836ad6e84281ee7d65d0d49d6fe85e9",
   "pins" : [
     {
       "identity" : "prynttrimmerview",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rewardstyle/prynttrimmerview",
       "state" : {
-        "revision" : "59379933130df86e35b6f6a60aefa7262368854a",
-        "version" : "4.0.4"
+        "branch" : "CC-2396-cover-photo-aspect-ratio",
+        "revision" : "5b9d108dad2fc626526f4b583b1e4910573df606"
       }
     },
     {
@@ -19,5 +20,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
This PR updates the version of `PryntTrimmerView` being used. For now it is a branch, but will be changed to a version when it's been verified and a release created.