### PR TITLE
fix: Allow overriding updateUI method in YPPickerVC

### DIFF
--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -281,8 +281,9 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         titleView.heightAnchor.constraint(equalToConstant: 40).isActive = true
         navigationItem.titleView = titleView
     }
-    
-    func updateUI() {
+
+    @objc
+    open func updateUI() {
         if !YPConfig.hidesCancelButton {
             // Update Nav Bar state.
             if let cancelButtonIcon = YPConfig.icons.cancelButtonIcon {


### PR DESCRIPTION
Just changing a function to `open` to allow subclasses to override it. 