### PR TITLE
fix: When adding more photo permissions, selected index could be misplaced

### DIFF
--- a/Source/Pages/Gallery/YPLibrary+LibraryChange.swift
+++ b/Source/Pages/Gallery/YPLibrary+LibraryChange.swift
@@ -81,6 +81,18 @@ extension YPLibraryVC: PHPhotoLibraryChangeObserver {
             }
         }
 
+        // If we had selected items before, we might need to update the currently selected index
+        if mediaManager.hasResultItems, !updatedItems.isEmpty, !isMultipleSelectionEnabled {
+            // Find the selected item that used to be at currently selected index and fix the index if it changed
+            let currentlySelectedAssetIdentifier = selectedItems[currentlySelectedIndex].assetIdentifier
+            if let currentlySelectedElement = mediaManager.getAsset(with: currentlySelectedAssetIdentifier),
+               let newIndex = mediaManager.fetchResult?.index(of: currentlySelectedElement),
+               newIndex != currentlySelectedIndex {
+                currentlySelectedIndex = newIndex
+            }
+        }
+
+
         // If user decided to forbid all photos with limited permission
         // while using the lib we need to remove asset from assets view.
         if selectedItems.isEmpty == false,

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -191,6 +191,7 @@ extension YPLibraryVC: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let previouslySelectedIndexPath = IndexPath(row: currentlySelectedIndex, section: 0)
         currentlySelectedIndex = indexPath.row
+        let previouslySelectedItemIdentifier = selectedItems.first(where: { $0.index == currentlySelectedIndex })?.assetIdentifier
 
         var shouldChangeAsset = true
         panGestureHelper.resetToOriginalState()
@@ -232,6 +233,12 @@ extension YPLibraryVC: UICollectionViewDelegate {
                 previousCell.isSelected = false
             }
             collectionView.reloadItems(at: [indexPath, previouslySelectedIndexPath])
+        } else if previouslySelectedIndexPath == indexPath, let currentItemIdentifier = mediaManager.getAsset(at: indexPath.row)?.localIdentifier, currentItemIdentifier != previouslySelectedItemIdentifier {
+            // If we clicked on the cell index that was already selected, but the identifier is different, let's re-select the cell
+            selectedItems.removeAll()
+            addToSelection(indexPath: indexPath)
+            shouldChangeAsset = true
+            collectionView.reloadItems(at: [indexPath])
         }
         if shouldChangeAsset {
             changeAsset(mediaManager.getAsset(at: indexPath.row))


### PR DESCRIPTION
Now, we fix the currentlySelectedIndex if needed after the photo is added, and when a cell is clicked, check if the asset is still the same it was when currentlySelectedIndex was set.

This fixes [CC-2851](https://rewardstyle.atlassian.net/browse/CC-2851)