### PR TITLE
fix: Reset thumb color to correct color, not white

### DIFF
--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -639,7 +639,7 @@ extension YPVideoFiltersVC: YPTimeStampTrimmerViewDelegate {
 // MARK: - ThumbSelectorViewDelegate
 extension YPVideoFiltersVC: ThumbSelectorViewDelegate {
     public func didChangeThumbPosition(_ imageTime: CMTime) {
-        coverThumbSelectorView.resetThumbViewBorderColor()
+        coverThumbSelectorView.resetThumbViewBorderColor(to: YPConfig.colors.coverSelectorBorderColor)
         // fetch new image
         if !isUsingCustomCoverImage || vcType == .Cover {
             generateCoverImageAtTime(imageTime)


### PR DESCRIPTION
Just a small bugfix: The cover thumb selector cover was incorrectly reset without parameters, which caused any custom colors to be overwritten to white. 