### PR TITLE
fix: Possible out-of-range indexing

### DIFF
--- a/Source/Pages/Gallery/YPLibrary+LibraryChange.swift
+++ b/Source/Pages/Gallery/YPLibrary+LibraryChange.swift
@@ -37,10 +37,11 @@ extension YPLibraryVC: PHPhotoLibraryChangeObserver {
                         collectionView.insertItems(at: insertedIndexes.aapl_indexPathsFromIndexesWithSection(0))
                     }
                 }, completion: { finished in
-                    guard finished,
-                          let changedIndexes = collectionChanges.changedIndexes,
+                    guard finished else { return }
+                    guard let changedIndexes = collectionChanges.changedIndexes,
                           changedIndexes.count != 0 else {
-                        ypLog("Some problems there.")
+                        ypLog("No changes detected")
+                        collectionView.reloadData() // If we failed to detect changes, we'll reload everything just in case
                         return
                     }
 
@@ -84,11 +85,13 @@ extension YPLibraryVC: PHPhotoLibraryChangeObserver {
         // If we had selected items before, we might need to update the currently selected index
         if mediaManager.hasResultItems, !updatedItems.isEmpty, !isMultipleSelectionEnabled {
             // Find the selected item that used to be at currently selected index and fix the index if it changed
-            let currentlySelectedAssetIdentifier = selectedItems[currentlySelectedIndex].assetIdentifier
-            if let currentlySelectedElement = mediaManager.getAsset(with: currentlySelectedAssetIdentifier),
-               let newIndex = mediaManager.fetchResult?.index(of: currentlySelectedElement),
-               newIndex != currentlySelectedIndex {
-                currentlySelectedIndex = newIndex
+            if currentlySelectedIndex >= 0 && currentlySelectedIndex < selectedItems.count {
+                let currentlySelectedAssetIdentifier = selectedItems[currentlySelectedIndex].assetIdentifier
+                if let currentlySelectedElement = mediaManager.getAsset(with: currentlySelectedAssetIdentifier),
+                   let newIndex = mediaManager.fetchResult?.index(of: currentlySelectedElement),
+                   newIndex != currentlySelectedIndex {
+                    currentlySelectedIndex = newIndex
+                }
             }
         }
 


### PR DESCRIPTION
The changes in https://github.com/rewardStyle/YPImagePicker/pull/63 caused an out-of-bounds indexing crash in some situations where the user's image gallery changed as the user was in the photo picker (like if a new photo was recently added). 

This change fixes that. 

Additionally, we now reload the gallery view properly when a new photo is added. 