### PR TITLE
chore: update stevia package to 6.2.0 for iOS 26 support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "PryntTrimmerView",
-        "repositoryURL": "https://github.com/HHK1/PryntTrimmerView",
+        "repositoryURL": "https://github.com/rewardStyle/PryntTrimmerView",
         "state": {
           "branch": null,
-          "revision": "ac1b60a22c7e6a6514de7a66d2f3d5b537c956d5",
-          "version": "4.0.2"
+          "revision": "7fd5aa8c4fe74c7e09e50b601fced68d1f3b10b9",
+          "version": "4.0.5"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/freshOS/Stevia",
         "state": {
           "branch": null,
-          "revision": "cfb1a1d2159277bb553c3dc46f3f742c0275566d",
-          "version": "5.1.2"
+          "revision": "a925d9b0087536c4ece110109c7815c988516135",
+          "version": "6.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/freshOS/Stevia",
-            .exact("5.1.2")
+            .upToNextMajor(from: "6.2.0")
         ),
         .package(
             url: "https://github.com/rewardStyle/PryntTrimmerView",

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/freshOS/Stevia",
-            .upToNextMajor(from: "6.2.0")
+            .exact("6.2.0")
         ),
         .package(
             url: "https://github.com/rewardStyle/PryntTrimmerView",


### PR DESCRIPTION
updated the stevia package to support iOS 26 and xcode 26