### PR TITLE
[Creator] feat: Secondary library button [CC-2966]

### DIFF
--- a/Source/Configuration/YPColors.swift
+++ b/Source/Configuration/YPColors.swift
@@ -77,6 +77,9 @@ public struct YPColors {
     /// The color of the button that changes between library and albums _when_ showsLibraryButtonInTitle is false
     public var libraryScreenAlbumsButtonColor: UIColor = .ypLabel
 
+    /// The color of the drafts button.
+    public var draftsButtonTextColor: UIColor = .ypSecondaryLabel
+
     // MARK: - Trimmer
     
     /// The color of the main border of the view

--- a/Source/Configuration/YPColors.swift
+++ b/Source/Configuration/YPColors.swift
@@ -77,8 +77,8 @@ public struct YPColors {
     /// The color of the button that changes between library and albums _when_ showsLibraryButtonInTitle is false
     public var libraryScreenAlbumsButtonColor: UIColor = .ypLabel
 
-    /// The color of the drafts button.
-    public var draftsButtonTextColor: UIColor = .ypSecondaryLabel
+    /// The color of the secondary library button.
+    public var secondaryLibraryButtonTextColor: UIColor = .ypSecondaryLabel
 
     // MARK: - Trimmer
     

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -109,8 +109,8 @@ public struct YPImagePickerConfiguration {
     /// Defines if the title bar should show the button that allows switching between the library and albums. If this is set to false, the button will be shown between the asset view and the library view instead
     public var showsLibraryButtonInTitle = true
 
-    /// Defines if the title bar should show the button that allows starting with a draft instead of media. Default if false.
-    public var showsDraftButtonInTitle = false
+    /// Defines if the title bar should show the secondary button next to the library button that can be configured. Default is false.
+    public var showsSecondaryLibraryButtonInTitle = false
 
     /// If showsLibraryButtonInTitle is false, this will be used as the title text instead
     public var pickerTitleOverride: String? = nil

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -109,6 +109,9 @@ public struct YPImagePickerConfiguration {
     /// Defines if the title bar should show the button that allows switching between the library and albums. If this is set to false, the button will be shown between the asset view and the library view instead
     public var showsLibraryButtonInTitle = true
 
+    /// Defines if the title bar should show the button that allows starting with a draft instead of media. Default if false.
+    public var showsDraftButtonInTitle = false
+
     /// If showsLibraryButtonInTitle is false, this will be used as the title text instead
     public var pickerTitleOverride: String? = nil
 

--- a/Source/Configuration/YPWordings.swift
+++ b/Source/Configuration/YPWordings.swift
@@ -35,7 +35,7 @@ public struct YPWordings {
     public var cover = ypLocalized("YPImagePickerCover")
     public var albumsTitle = ypLocalized("YPImagePickerAlbums")
     public var libraryTitle = ypLocalized("YPImagePickerLibrary")
-    public var draftsTitle = ypLocalized("YPImagePickerDrafts")
+    public var secondaryLibraryTitle = ypLocalized("YPImagePickerSecondary")
     public var cameraTitle = ypLocalized("YPImagePickerPhoto")
     public var videoTitle = ypLocalized("YPImagePickerVideo")
     public var next = ypLocalized("YPImagePickerNext")

--- a/Source/Configuration/YPWordings.swift
+++ b/Source/Configuration/YPWordings.swift
@@ -35,6 +35,7 @@ public struct YPWordings {
     public var cover = ypLocalized("YPImagePickerCover")
     public var albumsTitle = ypLocalized("YPImagePickerAlbums")
     public var libraryTitle = ypLocalized("YPImagePickerLibrary")
+    public var draftsTitle = ypLocalized("YPImagePickerDrafts")
     public var cameraTitle = ypLocalized("YPImagePickerPhoto")
     public var videoTitle = ypLocalized("YPImagePickerVideo")
     public var next = ypLocalized("YPImagePickerNext")

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -129,6 +129,10 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
         v.onAlbumsButtonTap = { [weak self] in
             self?.delegate?.libraryViewDidTapAlbum()
         }
+
+        v.onDraftsButtonTap = { [weak self] in
+            self?.delegate?.libraryViewDidTapDrafts()
+        }
     }
     
     public override func viewDidAppear(_ animated: Bool) {

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -130,8 +130,8 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
             self?.delegate?.libraryViewDidTapAlbum()
         }
 
-        v.onDraftsButtonTap = { [weak self] in
-            self?.delegate?.libraryViewDidTapDrafts()
+        v.onSecondaryButtonTap = { [weak self] in
+            self?.delegate?.libraryViewDidTapSecondaryButton()
         }
     }
     

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -86,6 +86,28 @@ internal final class YPLibraryView: UIView {
         return buttonContainerView
     }()
 
+    public let showDraftsButton: UIView = {
+        let containerView = UIView()
+
+        let label = UILabel()
+        label.text = YPConfig.wordings.draftsTitle
+        label.font = YPConfig.fonts.pickerTitleFont
+        label.textColor = YPConfig.colors.draftsButtonTextColor
+
+        let button = UIButton()
+        button.addTarget(self, action: #selector(draftsButtonTapped), for: .touchUpInside)
+        button.setBackgroundColor(YPConfig.colors.assetViewBackgroundColor.withAlphaComponent(0.4), forState: .highlighted)
+
+        containerView.subviews(label, button)
+        button.fillContainer()
+        |-(8)-label.centerHorizontally()-(8)-|
+
+        label.firstBaselineAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -24).isActive = true
+        containerView.heightAnchor.constraint(equalToConstant: 60).isActive = true
+
+        return containerView
+    }()
+
     public let multipleSelectionButton: UIButton = {
         let v = UIButton()
         v.setImage(YPConfig.icons.multipleSelectionOffIcon, for: .normal)
@@ -110,6 +132,7 @@ internal final class YPLibraryView: UIView {
     }()
 
     var onAlbumsButtonTap: (() -> Void)?
+    var onDraftsButtonTap: (() -> Void)?
 
     // MARK: - Private vars
 
@@ -312,6 +335,18 @@ internal final class YPLibraryView: UIView {
             bulkUploadRemoveAllButton.height(25).trailing(16)
             bulkUploadRemoveAllButton.layer.cornerRadius = 12.5
             align(horizontally: showAlbumsButton, bulkUploadRemoveAllButton)
+        } else if YPConfig.showsDraftButtonInTitle {
+            subviews(multipleSelectionButton)
+            multipleSelectionButton.size(30).trailing(16)
+            showAlbumsButton.leading(0)
+
+            subviews(showDraftsButton)
+            showDraftsButton.Top == showAlbumsButton.Top
+            showDraftsButton.Bottom == showAlbumsButton.Bottom
+            showDraftsButton.Leading == showAlbumsButton.Trailing
+            showDraftsButton.Trailing <= multipleSelectionButton.Leading - 16
+
+            align(horizontally: showAlbumsButton, showDraftsButton, multipleSelectionButton)
         } else {
             subviews(multipleSelectionButton)
             multipleSelectionButton.size(30).trailing(16)
@@ -322,5 +357,10 @@ internal final class YPLibraryView: UIView {
     @objc
     func albumsButtonTapped() {
         onAlbumsButtonTap?()
+    }
+
+    @objc
+    func draftsButtonTapped() {
+        onDraftsButtonTap?()
     }
 }

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -86,16 +86,16 @@ internal final class YPLibraryView: UIView {
         return buttonContainerView
     }()
 
-    public let showDraftsButton: UIView = {
+    public let secondaryButton: UIView = {
         let containerView = UIView()
 
         let label = UILabel()
-        label.text = YPConfig.wordings.draftsTitle
+        label.text = YPConfig.wordings.secondaryLibraryTitle
         label.font = YPConfig.fonts.pickerTitleFont
-        label.textColor = YPConfig.colors.draftsButtonTextColor
+        label.textColor = YPConfig.colors.secondaryLibraryButtonTextColor
 
         let button = UIButton()
-        button.addTarget(self, action: #selector(draftsButtonTapped), for: .touchUpInside)
+        button.addTarget(self, action: #selector(secondaryButtonTapped), for: .touchUpInside)
         button.setBackgroundColor(YPConfig.colors.assetViewBackgroundColor.withAlphaComponent(0.4), forState: .highlighted)
 
         containerView.subviews(label, button)
@@ -132,7 +132,7 @@ internal final class YPLibraryView: UIView {
     }()
 
     var onAlbumsButtonTap: (() -> Void)?
-    var onDraftsButtonTap: (() -> Void)?
+    var onSecondaryButtonTap: (() -> Void)?
 
     // MARK: - Private vars
 
@@ -335,18 +335,18 @@ internal final class YPLibraryView: UIView {
             bulkUploadRemoveAllButton.height(25).trailing(16)
             bulkUploadRemoveAllButton.layer.cornerRadius = 12.5
             align(horizontally: showAlbumsButton, bulkUploadRemoveAllButton)
-        } else if YPConfig.showsDraftButtonInTitle {
+        } else if YPConfig.showsSecondaryLibraryButtonInTitle {
             subviews(multipleSelectionButton)
             multipleSelectionButton.size(30).trailing(16)
             showAlbumsButton.leading(0)
 
-            subviews(showDraftsButton)
-            showDraftsButton.Top == showAlbumsButton.Top
-            showDraftsButton.Bottom == showAlbumsButton.Bottom
-            showDraftsButton.Leading == showAlbumsButton.Trailing
-            showDraftsButton.Trailing <= multipleSelectionButton.Leading - 16
+            subviews(secondaryButton)
+            secondaryButton.Top == showAlbumsButton.Top
+            secondaryButton.Bottom == showAlbumsButton.Bottom
+            secondaryButton.Leading == showAlbumsButton.Trailing
+            secondaryButton.Trailing <= multipleSelectionButton.Leading - 16
 
-            align(horizontally: showAlbumsButton, showDraftsButton, multipleSelectionButton)
+            align(horizontally: showAlbumsButton, secondaryButton, multipleSelectionButton)
         } else {
             subviews(multipleSelectionButton)
             multipleSelectionButton.size(30).trailing(16)
@@ -360,7 +360,7 @@ internal final class YPLibraryView: UIView {
     }
 
     @objc
-    func draftsButtonTapped() {
-        onDraftsButtonTap?()
+    func secondaryButtonTapped() {
+        onSecondaryButtonTap?()
     }
 }

--- a/Source/Pages/Gallery/YPLibraryViewDelegate.swift
+++ b/Source/Pages/Gallery/YPLibraryViewDelegate.swift
@@ -17,4 +17,5 @@ public protocol YPLibraryViewDelegate: AnyObject {
     func libraryViewShouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool
     func libraryViewHaveNoItems()
     func libraryViewDidTapAlbum()
+    func libraryViewDidTapDrafts()
 }

--- a/Source/Pages/Gallery/YPLibraryViewDelegate.swift
+++ b/Source/Pages/Gallery/YPLibraryViewDelegate.swift
@@ -17,5 +17,5 @@ public protocol YPLibraryViewDelegate: AnyObject {
     func libraryViewShouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool
     func libraryViewHaveNoItems()
     func libraryViewDidTapAlbum()
-    func libraryViewDidTapDrafts()
+    func libraryViewDidTapSecondaryButton()
 }

--- a/Source/Resources/en.lproj/YPImagePickerLocalizable.strings
+++ b/Source/Resources/en.lproj/YPImagePickerLocalizable.strings
@@ -5,7 +5,7 @@
 "YPImagePickerDone" = "Done";
 "YPImagePickerFilter" = "Filter";
 "YPImagePickerLibrary" = "Library";
-"YPImagePickerDrafts" = "Drafts";
+"YPImagePickerSecondary" = "Secondary";
 "YPImagePickerNext" = "Next";
 "YPImagePickerOk" = "Ok";
 "YPImagePickerPermissionDeniedPopupCancel" = "Cancel";

--- a/Source/Resources/en.lproj/YPImagePickerLocalizable.strings
+++ b/Source/Resources/en.lproj/YPImagePickerLocalizable.strings
@@ -5,6 +5,7 @@
 "YPImagePickerDone" = "Done";
 "YPImagePickerFilter" = "Filter";
 "YPImagePickerLibrary" = "Library";
+"YPImagePickerDrafts" = "Drafts";
 "YPImagePickerNext" = "Next";
 "YPImagePickerOk" = "Ok";
 "YPImagePickerPermissionDeniedPopupCancel" = "Cancel";

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -37,7 +37,7 @@ open class YPImagePicker: UINavigationController {
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen // Force .fullScreen as iOS 13 now shows modals as cards by default.
         picker.pickerVCDelegate = self
-        picker.didTapDrafts = { [weak self] in
+        picker.didTapSecondaryLibraryButton = { [weak self] in
             self?.pushViewController(UIViewController(), animated: true)
         }
     }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -37,6 +37,9 @@ open class YPImagePicker: UINavigationController {
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen // Force .fullScreen as iOS 13 now shows modals as cards by default.
         picker.pickerVCDelegate = self
+        picker.didTapDrafts = { [weak self] in
+            self?.pushViewController(UIViewController(), animated: true)
+        }
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -31,7 +31,7 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     public var didClose:(() -> Void)?
     public var didSelectItems: (([YPMediaItem]) -> Void)?
     public var didTapMultipleSelection: ((Bool) -> Void)?
-    public var didTapDrafts: (() -> Void)?
+    public var didTapSecondaryLibraryButton: (() -> Void)?
     public var viewDidAppear: ((AnyObject) -> Void)?
     
     enum Mode {
@@ -423,8 +423,8 @@ extension YPPickerVC: YPLibraryViewDelegate {
         return pickerVCDelegate?.shouldAddToSelection(indexPath: indexPath, numSelections: numSelections) ?? true
     }
 
-    public func libraryViewDidTapDrafts() {
-        didTapDrafts?()
+    public func libraryViewDidTapSecondaryButton() {
+        didTapSecondaryLibraryButton?()
     }
 
     public func libraryViewDidTapAlbum() {

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -31,6 +31,7 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     public var didClose:(() -> Void)?
     public var didSelectItems: (([YPMediaItem]) -> Void)?
     public var didTapMultipleSelection: ((Bool) -> Void)?
+    public var didTapDrafts: (() -> Void)?
     public var viewDidAppear: ((AnyObject) -> Void)?
     
     enum Mode {
@@ -420,6 +421,10 @@ extension YPPickerVC: YPLibraryViewDelegate {
     
     public func libraryViewShouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool {
         return pickerVCDelegate?.shouldAddToSelection(indexPath: indexPath, numSelections: numSelections) ?? true
+    }
+
+    public func libraryViewDidTapDrafts() {
+        didTapDrafts?()
     }
 
     public func libraryViewDidTapAlbum() {


### PR DESCRIPTION
### Description
This PR adds the ability to show and configure a second button next to the library/album button in the library view. It is not shown by default so without any changes this will not change the behavior of any consuming projects. 

### Screenshot
| Config flag off | Config flag on |
| ---- | -- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/051a1f6e-76a0-4cc0-bccb-838ae4ae6991" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/347223a5-dc11-4bd5-8ba7-d36d5eb9db79" /> |
