### PR TITLE
[Creator] feat: expose secondary library button [CC-3095]

### DIFF
--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -37,7 +37,7 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     public var didSelectItems: (([YPMediaItem]) -> Void)?
     public var didTapMultipleSelection: ((Bool) -> Void)?
     public var didTapSecondaryLibraryButton: (() -> Void)?
-    public var viewDidAppear: ((AnyObject, AnyObject) -> Void)?
+    public var viewDidAppear: (() -> Void)?
     
     enum Mode {
         case library
@@ -149,6 +149,7 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
 
         libraryVC?.v.showAlbumsButton.tag = LibraryButtonTags.showAlbumsButton
         libraryVC?.v.secondaryButton.tag = LibraryButtonTags.secondaryButton
+        viewDidAppear?()
     }
 
     internal func pagerScrollViewDidScroll(_ scrollView: UIScrollView) { }


### PR DESCRIPTION
This PR updates the `viewDidLoad` callback of `YPPickerVC` to not include any buttons. Instead it sets the tag of the buttons that have tooltips currently and exposes the tags so they can be accessed via `viewWithTag`.