### PR TITLE
[CRE-1055] fix: Limited photo permissions

### DIFF
--- a/Source/Helpers/Permissions/YPPermissionCheckable.swift
+++ b/Source/Helpers/Permissions/YPPermissionCheckable.swift
@@ -9,18 +9,19 @@
 import UIKit
 
 internal protocol YPPermissionCheckable {
-    func doAfterLibraryPermissionCheck(block: @escaping () -> Void)
+    func doAfterLibraryPermissionCheck(block: @escaping () -> Void, permissionDeniedBlock: (() -> Void)?)
     func doAfterCameraPermissionCheck(block: @escaping () -> Void)
     func checkLibraryPermission()
     func checkCameraPermission()
 }
 
 internal extension YPPermissionCheckable where Self: UIViewController {
-    func doAfterLibraryPermissionCheck(block: @escaping () -> Void) {
+    func doAfterLibraryPermissionCheck(block: @escaping () -> Void, permissionDeniedBlock: (() -> Void)? = nil) {
         YPPermissionManager.checkLibraryPermissionAndAskIfNeeded(sourceVC: self) { hasPermission in
             if hasPermission {
                 block()
             } else {
+                permissionDeniedBlock?()
                 ypLog("Not enough permissions.")
             }
         }

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -299,12 +299,17 @@ public final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                 addToSelection(assetIndex: 0)
             }
         } else {
-            delegate?.libraryViewHaveNoItems()
+            libraryViewHaveNoItems()
         }
 
         scrollToTop()
     }
-    
+
+    func libraryViewHaveNoItems() {
+        v.hideLoader()
+        delegate?.libraryViewHaveNoItems()
+    }
+
     func buildPHFetchOptions() -> PHFetchOptions {
         // Sorting condition
         if let userOpt = YPConfig.library.options {

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -187,11 +187,11 @@ open class YPImagePicker: UINavigationController {
 }
 
 extension YPImagePicker: YPPickerVCDelegate {
-    func libraryHasNoItems() {
+    public func libraryHasNoItems() {
         self.imagePickerDelegate?.imagePickerHasNoItemsInLibrary(self)
     }
     
-    func shouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool {
+    public func shouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool {
         return self.imagePickerDelegate?.shouldAddToSelection(indexPath: indexPath, numSelections: numSelections)
             ?? true
     }

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -10,7 +10,7 @@ import UIKit
 import Stevia
 import Photos
 
-protocol YPPickerVCDelegate: AnyObject {
+public protocol YPPickerVCDelegate: AnyObject {
     func libraryHasNoItems()
     func shouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool
 }
@@ -26,7 +26,7 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     let albumsManager = YPAlbumsManager()
     var shouldHideStatusBar = false
     var initialStatusBarHidden = false
-    weak var pickerVCDelegate: YPPickerVCDelegate?
+    public weak var pickerVCDelegate: YPPickerVCDelegate?
     
     override open var prefersStatusBarHidden: Bool {
         return (shouldHideStatusBar || initialStatusBarHidden) && YPConfig.hidesStatusBar

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -181,9 +181,11 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         
         // Re-trigger permission check
         if let vc = vc as? YPLibraryVC {
-            vc.doAfterLibraryPermissionCheck { [weak vc] in
+            vc.doAfterLibraryPermissionCheck(block: { [weak vc] in
                 vc?.initialize()
-            }
+            }, permissionDeniedBlock: { [weak vc] in
+                vc?.libraryViewHaveNoItems()
+            })
         } else if let cameraVC = vc as? YPCameraVC {
             cameraVC.start()
         } else if let videoVC = vc as? YPVideoCaptureVC {


### PR DESCRIPTION
This PR fixes a couple issues:
- Loading indicator stops when there is no media to load
- Calls `libraryViewHaveNoItems` when photo permissions is denied